### PR TITLE
feat: Add weight and fontStyle props to Text component

### DIFF
--- a/.changeset/pink-socks-shave.md
+++ b/.changeset/pink-socks-shave.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+feat: Add weight and fontStyle props to Text component

--- a/public/pte.css
+++ b/public/pte.css
@@ -104,6 +104,18 @@
     --pte-typography-boldFontWeight: 500;
     --pte-typography-italicLetterSpacing: -0.01em;
     --pte-typography-verticalMetricsAdjust: 1px;
+    --pte-typography-fontWeights-thin: 100;
+    --pte-typography-fontWeights-extraLight: 200;
+    --pte-typography-fontWeights-light: 300;
+    --pte-typography-fontWeights-normal: 400;
+    --pte-typography-fontWeights-medium: 500;
+    --pte-typography-fontWeights-semiBold: 600;
+    --pte-typography-fontWeights-bold: 700;
+    --pte-typography-fontWeights-extraBold: 800;
+    --pte-typography-fontWeights-black: 900;
+    --pte-typography-fontWeights-extraBlack: 950;
+    --pte-typography-fontStyles-italic: italic;
+    --pte-typography-fontStyles-normal: normal;
     --pte-typography-styles-displayLarge-fontStyle: normal;
     --pte-typography-styles-displayLarge-letterSpacing: -0.01em;
     --pte-typography-styles-displayLarge-fontWeight: 600;

--- a/public/pte.css
+++ b/public/pte.css
@@ -101,7 +101,6 @@
     --pte-colors-borderInverseOpaque: #3c3c3c;
     --pte-colors-borderInverseSelected: #e2e2e2;
     --pte-typography-fontFamily: "Graphik Web", -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif;
-    --pte-typography-boldFontWeight: 500;
     --pte-typography-italicLetterSpacing: -0.01em;
     --pte-typography-verticalMetricsAdjust: 1px;
     --pte-typography-fontWeights-thin: 100;

--- a/scripts/text.ts
+++ b/scripts/text.ts
@@ -62,6 +62,7 @@ export const generateTextStories = async () => {
         ['paragraphMediumBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphMedium', weight: 'bold' } }],
         ['paragraphSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphSmall', weight: 'bold' } }],
         ['paragraphXSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphXSmall', weight: 'bold' } }],
+        ['paragraphLargeItalic', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphLarge', style: 'italic' } }],
     ];
 
     const stories = [...typographyStories, ...styledStories];

--- a/scripts/text.ts
+++ b/scripts/text.ts
@@ -46,7 +46,7 @@ export const text = async () => {
  * Generates Storybook stories for each typography class.
  */
 export const generateTextStories = async () => {
-    const stories: Array<[string, StoryObj<typeof Text>]> = Object.keys(LightTheme.typography.styles)
+    const typographyStories: Array<[string, StoryObj<typeof Text>]> = Object.keys(LightTheme.typography.styles)
         .map((style) => ([
             style,
             {
@@ -56,6 +56,15 @@ export const generateTextStories = async () => {
                 },
             } as StoryObj<typeof Text>,
         ]));
+
+    const styledStories: Array<[string, StoryObj<typeof Text>]> = [
+        ['paragraphLargeBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphLarge', weight: 'bold' } }],
+        ['paragraphMediumBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphMedium', weight: 'bold' } }],
+        ['paragraphSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphSmall', weight: 'bold' } }],
+        ['paragraphXSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphXSmall', weight: 'bold' } }],
+    ];
+
+    const stories = [...typographyStories, ...styledStories];
 
     // Retrieve current stories
     const currentStories = await fs.readFile('src/stories/text/Text.stories.ts', 'utf-8');

--- a/scripts/text.ts
+++ b/scripts/text.ts
@@ -58,10 +58,10 @@ export const generateTextStories = async () => {
         ]));
 
     const styledStories: Array<[string, StoryObj<typeof Text>]> = [
-        ['paragraphLargeBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphLarge', weight: 'bold' } }],
-        ['paragraphMediumBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphMedium', weight: 'bold' } }],
-        ['paragraphSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphSmall', weight: 'bold' } }],
-        ['paragraphXSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphXSmall', weight: 'bold' } }],
+        ['paragraphLargeBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphLarge', weight: 'medium' } }],
+        ['paragraphMediumBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphMedium', weight: 'medium' } }],
+        ['paragraphSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphSmall', weight: 'medium' } }],
+        ['paragraphXSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphXSmall', weight: 'medium' } }],
         ['paragraphLargeItalic', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphLarge', fontStyle: 'italic' } }],
     ];
 

--- a/scripts/text.ts
+++ b/scripts/text.ts
@@ -62,7 +62,7 @@ export const generateTextStories = async () => {
         ['paragraphMediumBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphMedium', weight: 'bold' } }],
         ['paragraphSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphSmall', weight: 'bold' } }],
         ['paragraphXSmallBold', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphXSmall', weight: 'bold' } }],
-        ['paragraphLargeItalic', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphLarge', style: 'italic' } }],
+        ['paragraphLargeItalic', { args: { children: 'In an alleyway, drinking champagne', kind: 'paragraphLarge', fontStyle: 'italic' } }],
     ];
 
     const stories = [...typographyStories, ...styledStories];

--- a/src/stories/Tokens.mdx
+++ b/src/stories/Tokens.mdx
@@ -36,7 +36,7 @@ Tokens are the smallest pieces of design language that can be used to build comp
                 }}
             />
             <div style={{ color: pvar('colors.contentPrimary') }}>
-                <span style={{ fontWeight: pvar('typography.boldFontWeight') }}>{key}</span>
+                <span style={{ fontWeight: pvar('typography.fontWeights.medium') }}>{key}</span>
                 <br />
                 <pre style={{ fontSize: '14px' }}>{pget(`colors.${key}`)}</pre>
             </div>

--- a/src/stories/input/Input.module.scss
+++ b/src/stories/input/Input.module.scss
@@ -63,7 +63,8 @@
         }
     }
 
-    & input, & textarea {
+    & input,
+    & textarea {
         width: 100%;
         background-color: transparent;
         padding: 0;
@@ -122,7 +123,7 @@
 // Use double selector to ensure specificity is higher than the default styles
 .label.label {
     color: var(--pte-colors-contentPrimary);
-    font-weight: var(--pte-typography-boldFontWeight);
+    font-weight: var(--pte-typography-fontWeights-medium);
 }
 
 // Use double selector to ensure specificity is higher than the default styles

--- a/src/stories/text/Text.module.scss
+++ b/src/stories/text/Text.module.scss
@@ -17,11 +17,6 @@ $text-weights: (
     "bold": bold,
     "lighter": lighter,
     "bolder": bolder,
-    "inherit": inherit,
-    "initial": initial,
-    "revert": revert,
-    "revert-layer": revert-layer,
-    "unset": unset
 );
 
 @each $weight-name,
@@ -42,5 +37,26 @@ $font-styles: (
 $style-value in $font-styles {
     .fontStyle-#{$style-name} {
         font-style: $style-value;
+    }
+}
+
+/* Global values */
+$global-values: (
+    "inherit": inherit,
+    "initial": initial,
+    "revert": revert,
+    "revert-layer": revert-layer,
+    "unset": unset
+);
+
+/* Generate global value classes */
+@each $global-name,
+$global-value in $global-values {
+    .weight-#{$global-name} {
+        font-weight: $global-value;
+    }
+
+    .fontStyle-#{$global-name} {
+        font-style: $global-value;
     }
 }

--- a/src/stories/text/Text.module.scss
+++ b/src/stories/text/Text.module.scss
@@ -46,3 +46,16 @@
 .weight-unset {
     font-weight: unset;
 }
+
+$font-styles: (
+    "normal": normal,
+    "italic": italic,
+    "oblique": oblique,
+);
+
+@each $style-name,
+$style-value in $font-styles {
+    .style-#{$style-name} {
+        font-style: $style-value;
+    }
+}

--- a/src/stories/text/Text.module.scss
+++ b/src/stories/text/Text.module.scss
@@ -2,6 +2,7 @@
     font-family: var(--pte-typography-fontFamily);
 }
 
+/* Font weight numberic values */
 @for $i from 1 through 9 {
     $weight: $i * 100;
 
@@ -10,43 +11,27 @@
     }
 }
 
-/* Additional classes for keyword values */
-.weight-normal {
-    font-weight: normal;
+/* Font weight keyword values */
+$text-weights: (
+    "normal": normal,
+    "bold": bold,
+    "lighter": lighter,
+    "bolder": bolder,
+    "inherit": inherit,
+    "initial": initial,
+    "revert": revert,
+    "revert-layer": revert-layer,
+    "unset": unset
+);
+
+@each $weight-name,
+$weight-value in $text-weights {
+    .weight-#{$weight-name} {
+        font-weight: $weight-value;
+    }
 }
 
-.weight-bold {
-    font-weight: bold;
-}
-
-.weight-lighter {
-    font-weight: lighter;
-}
-
-.weight-bolder {
-    font-weight: bolder;
-}
-
-.weight-inherit {
-    font-weight: inherit;
-}
-
-.weight-initial {
-    font-weight: initial;
-}
-
-.weight-revert {
-    font-weight: revert;
-}
-
-.weight-revert-layer {
-    font-weight: revert-layer;
-}
-
-.weight-unset {
-    font-weight: unset;
-}
-
+/* Font style keyword values */
 $font-styles: (
     "normal": normal,
     "italic": italic,

--- a/src/stories/text/Text.module.scss
+++ b/src/stories/text/Text.module.scss
@@ -1,3 +1,48 @@
 .text {
     font-family: var(--pte-typography-fontFamily);
 }
+
+@for $i from 1 through 9 {
+    $weight: $i * 100;
+
+    .weight-#{$weight} {
+        font-weight: $weight;
+    }
+}
+
+/* Additional classes for keyword values */
+.weight-normal {
+    font-weight: normal;
+}
+
+.weight-bold {
+    font-weight: bold;
+}
+
+.weight-lighter {
+    font-weight: lighter;
+}
+
+.weight-bolder {
+    font-weight: bolder;
+}
+
+.weight-inherit {
+    font-weight: inherit;
+}
+
+.weight-initial {
+    font-weight: initial;
+}
+
+.weight-revert {
+    font-weight: revert;
+}
+
+.weight-revert-layer {
+    font-weight: revert-layer;
+}
+
+.weight-unset {
+    font-weight: unset;
+}

--- a/src/stories/text/Text.module.scss
+++ b/src/stories/text/Text.module.scss
@@ -2,22 +2,20 @@
     font-family: var(--pte-typography-fontFamily);
 }
 
-/* Font weight numberic values */
-@for $i from 1 through 9 {
-    $weight: $i * 100;
-
-    .weight-#{$weight} {
-        font-weight: $weight;
-    }
-}
-
-/* Font weight keyword values */
+/* Font weight theme values */
 $text-weights: (
-    "normal": normal,
-    "bold": bold,
-    "lighter": lighter,
-    "bolder": bolder,
+    "thin": var(--pte-typography-fontWeights-thin),
+    "extraLight": var(--pte-typography-fontWeights-extraLight),
+    "light": var(--pte-typography-fontWeights-light),
+    "normal": var(--pte-typography-fontWeights-normal),
+    "medium": var(--pte-typography-fontWeights-medium),
+    "semiBold": var(--pte-typography-fontWeights-semiBold),
+    "bold": var(--pte-typography-fontWeights-bold),
+    "extraBold": var(--pte-typography-fontWeights-extraBold),
+    "black": var(--pte-typography-fontWeights-black),
+    "extraBlack": var(--pte-typography-fontWeights-extraBlack),
 );
+
 
 @each $weight-name,
 $weight-value in $text-weights {
@@ -26,37 +24,15 @@ $weight-value in $text-weights {
     }
 }
 
-/* Font style keyword values */
+/* Font style theme values */
 $font-styles: (
-    "normal": normal,
-    "italic": italic,
-    "oblique": oblique,
+    "normal": var(--pte-typography-fontStyles-normal),
+    "italic": var(--pte-typography-fontStyles-italic),
 );
 
 @each $style-name,
 $style-value in $font-styles {
     .fontStyle-#{$style-name} {
         font-style: $style-value;
-    }
-}
-
-/* Global values */
-$global-values: (
-    "inherit": inherit,
-    "initial": initial,
-    "revert": revert,
-    "revert-layer": revert-layer,
-    "unset": unset
-);
-
-/* Generate global value classes */
-@each $global-name,
-$global-value in $global-values {
-    .weight-#{$global-name} {
-        font-weight: $global-value;
-    }
-
-    .fontStyle-#{$global-name} {
-        font-style: $global-value;
     }
 }

--- a/src/stories/text/Text.module.scss
+++ b/src/stories/text/Text.module.scss
@@ -40,7 +40,7 @@ $font-styles: (
 
 @each $style-name,
 $style-value in $font-styles {
-    .style-#{$style-name} {
+    .fontStyle-#{$style-name} {
         font-style: $style-value;
     }
 }

--- a/src/stories/text/Text.stories.ts
+++ b/src/stories/text/Text.stories.ts
@@ -188,7 +188,7 @@ export const ParagraphLargeItalic: Story = {
     args: {
         children: 'In an alleyway, drinking champagne',
         kind: 'paragraphLarge',
-        style: 'italic',
+        fontStyle: 'italic',
     },
 };
 

--- a/src/stories/text/Text.stories.ts
+++ b/src/stories/text/Text.stories.ts
@@ -184,4 +184,12 @@ export const ParagraphXSmallBold: Story = {
     },
 };
 
+export const ParagraphLargeItalic: Story = {
+    args: {
+        children: 'In an alleyway, drinking champagne',
+        kind: 'paragraphLarge',
+        style: 'italic',
+    },
+};
+
 // @auto-generated-end

--- a/src/stories/text/Text.stories.ts
+++ b/src/stories/text/Text.stories.ts
@@ -156,7 +156,7 @@ export const ParagraphLargeBold: Story = {
     args: {
         children: 'In an alleyway, drinking champagne',
         kind: 'paragraphLarge',
-        weight: 'bold',
+        weight: 'medium',
     },
 };
 
@@ -164,7 +164,7 @@ export const ParagraphMediumBold: Story = {
     args: {
         children: 'In an alleyway, drinking champagne',
         kind: 'paragraphMedium',
-        weight: 'bold',
+        weight: 'medium',
     },
 };
 
@@ -172,7 +172,7 @@ export const ParagraphSmallBold: Story = {
     args: {
         children: 'In an alleyway, drinking champagne',
         kind: 'paragraphSmall',
-        weight: 'bold',
+        weight: 'medium',
     },
 };
 
@@ -180,7 +180,7 @@ export const ParagraphXSmallBold: Story = {
     args: {
         children: 'In an alleyway, drinking champagne',
         kind: 'paragraphXSmall',
-        weight: 'bold',
+        weight: 'medium',
     },
 };
 

--- a/src/stories/text/Text.stories.ts
+++ b/src/stories/text/Text.stories.ts
@@ -152,4 +152,36 @@ export const ParagraphXXSmall: Story = {
     },
 };
 
+export const ParagraphLargeBold: Story = {
+    args: {
+        children: 'In an alleyway, drinking champagne',
+        kind: 'paragraphLarge',
+        weight: 'bold',
+    },
+};
+
+export const ParagraphMediumBold: Story = {
+    args: {
+        children: 'In an alleyway, drinking champagne',
+        kind: 'paragraphMedium',
+        weight: 'bold',
+    },
+};
+
+export const ParagraphSmallBold: Story = {
+    args: {
+        children: 'In an alleyway, drinking champagne',
+        kind: 'paragraphSmall',
+        weight: 'bold',
+    },
+};
+
+export const ParagraphXSmallBold: Story = {
+    args: {
+        children: 'In an alleyway, drinking champagne',
+        kind: 'paragraphXSmall',
+        weight: 'bold',
+    },
+};
+
 // @auto-generated-end

--- a/src/stories/text/Text.tsx
+++ b/src/stories/text/Text.tsx
@@ -3,12 +3,10 @@ import { createElement } from 'react';
 import clsx from 'clsx';
 import typography from './Typography.module.css';
 import styles from './Text.module.scss';
-import type { LightTheme } from '../theme';
+import type { LightTheme, Theme } from '../theme';
 
 export type TextElement = 'p' | 'span' | 'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'label' | 'legend' | 'caption' | 'small';
 export type GlobalCSSValues = 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset';
-export type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 'normal' | 'bold' | 'lighter' | 'bolder' | GlobalCSSValues;
-export type FontStyle = 'normal' | 'italic' | 'oblique' | GlobalCSSValues;
 
 export type TextProps<T extends TextElement = 'span'> = {
     /**
@@ -26,12 +24,12 @@ export type TextProps<T extends TextElement = 'span'> = {
     /**
      * The font weight to apply.
      */
-    weight?: FontWeight;
+    weight?: keyof typeof LightTheme.typography.fontWeights;
 
     /**
      * The font style to apply.
      */
-    fontStyle?: FontStyle;
+    fontStyle?: keyof typeof LightTheme.typography.fontStyles;
 
     /** The contents of the Text element. */
     children: ReactNode;

--- a/src/stories/text/Text.tsx
+++ b/src/stories/text/Text.tsx
@@ -30,7 +30,7 @@ export type TextProps<T extends TextElement = 'span'> = {
     /**
      * The font style to apply.
      */
-    style?: FontStyle;
+    fontStyle?: FontStyle;
 
     /** The contents of the Text element. */
     children: ReactNode;
@@ -60,7 +60,7 @@ export function Text<T extends TextElement>({
     kind,
     as,
     weight,
-    style,
+    fontStyle,
     children,
     ...props
 }: TextProps<T>): JSX.Element {
@@ -72,7 +72,7 @@ export function Text<T extends TextElement>({
                 styles.text,
                 typography[kind || 'paragraphMedium'],
                 weight && `weight-${weight}`,
-                style && `style-${style}`,
+                fontStyle && `fontStyle-${fontStyle}`,
                 props?.className,
             ),
         },

--- a/src/stories/text/Text.tsx
+++ b/src/stories/text/Text.tsx
@@ -6,17 +6,25 @@ import typography from './Typography.module.css';
 import type { LightTheme } from '../theme';
 
 export type TextElement = 'p' | 'span' | 'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'label' | 'legend' | 'caption' | 'small';
+export type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 'normal' | 'bold' | 'lighter' | 'bolder' | 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset';
 export type TextProps<T extends TextElement = 'span'> = {
     /**
      * The font class to use.
      * @default paragraphMedium
      */
     kind?: keyof typeof LightTheme.typography.styles;
+
     /**
      * The HTML text tag to use.
      * @default span
      */
     as?: T;
+
+    /**
+     * The font weight to apply.
+     */
+    weight?: FontWeight;
+
     /** The contents of the Text element. */
     children: ReactNode;
 } & ComponentProps<T>;
@@ -32,7 +40,7 @@ export type TextProps<T extends TextElement = 'span'> = {
  * import { Text } from 'paris/text';
  *
  * export const ExampleHeading: FC = () => (
- *     <Text as="h1" kind="headingLarge">Hello World!</Text>
+ *     <Text as="h1" kind="headingLarge" weight="bold">Hello World!</Text>
  * );
  * ```
  *
@@ -44,6 +52,7 @@ export type TextProps<T extends TextElement = 'span'> = {
 export function Text<T extends TextElement>({
     kind,
     as,
+    weight,
     children,
     ...props
 }: TextProps<T>): JSX.Element {
@@ -54,6 +63,7 @@ export function Text<T extends TextElement>({
             className: clsx(
                 styles.text,
                 typography[kind || 'paragraphMedium'],
+                weight && `weight-${weight}`,
                 props?.className,
             ),
         },

--- a/src/stories/text/Text.tsx
+++ b/src/stories/text/Text.tsx
@@ -7,6 +7,8 @@ import type { LightTheme } from '../theme';
 
 export type TextElement = 'p' | 'span' | 'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'label' | 'legend' | 'caption' | 'small';
 export type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 'normal' | 'bold' | 'lighter' | 'bolder' | 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset';
+export type FontStyle = 'normal' | 'italic' | 'oblique';
+
 export type TextProps<T extends TextElement = 'span'> = {
     /**
      * The font class to use.
@@ -25,6 +27,11 @@ export type TextProps<T extends TextElement = 'span'> = {
      */
     weight?: FontWeight;
 
+    /**
+     * The font style to apply.
+     */
+    style?: FontStyle;
+
     /** The contents of the Text element. */
     children: ReactNode;
 } & ComponentProps<T>;
@@ -40,7 +47,7 @@ export type TextProps<T extends TextElement = 'span'> = {
  * import { Text } from 'paris/text';
  *
  * export const ExampleHeading: FC = () => (
- *     <Text as="h1" kind="headingLarge" weight="bold">Hello World!</Text>
+ *     <Text as="h1" kind="headingLarge" weight="bold" style="italic">Hello World!</Text>
  * );
  * ```
  *
@@ -53,6 +60,7 @@ export function Text<T extends TextElement>({
     kind,
     as,
     weight,
+    style,
     children,
     ...props
 }: TextProps<T>): JSX.Element {
@@ -64,6 +72,7 @@ export function Text<T extends TextElement>({
                 styles.text,
                 typography[kind || 'paragraphMedium'],
                 weight && `weight-${weight}`,
+                style && `style-${style}`,
                 props?.className,
             ),
         },

--- a/src/stories/text/Text.tsx
+++ b/src/stories/text/Text.tsx
@@ -32,12 +32,12 @@ export type TextProps<T extends TextElement = 'span'> = {
  * import { Text } from 'paris/text';
  *
  * export const ExampleHeading: FC = () => (
- *     <Text as="h1" format="headingLarge">Hello World!</Text>
+ *     <Text as="h1" kind="headingLarge">Hello World!</Text>
  * );
  * ```
  *
  * @example ```tsx
- * <Text as="h1" format="headingLarge">Hello World!</Text>
+ * <Text as="h1" kind="headingLarge">Hello World!</Text>
  * ```
  * @constructor
  */

--- a/src/stories/text/Text.tsx
+++ b/src/stories/text/Text.tsx
@@ -1,8 +1,8 @@
 import type { ComponentProps, FC, ReactNode } from 'react';
 import { createElement } from 'react';
 import clsx from 'clsx';
-import styles from './Text.module.scss';
 import typography from './Typography.module.css';
+import styles from './Text.module.scss';
 import type { LightTheme } from '../theme';
 
 export type TextElement = 'p' | 'span' | 'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'label' | 'legend' | 'caption' | 'small';
@@ -47,7 +47,7 @@ export type TextProps<T extends TextElement = 'span'> = {
  * import { Text } from 'paris/text';
  *
  * export const ExampleHeading: FC = () => (
- *     <Text as="h1" kind="headingLarge" weight="bold" style="italic">Hello World!</Text>
+ *     <Text as="h1" kind="headingLarge" weight="bold" fontStyle="italic">Hello World!</Text>
  * );
  * ```
  *
@@ -70,9 +70,9 @@ export function Text<T extends TextElement>({
             ...props,
             className: clsx(
                 styles.text,
+                typography[kind || 'paragraphMedium'],
                 weight && styles[`weight-${weight}`],
                 fontStyle && styles[`fontStyle-${fontStyle}`],
-                typography[kind || 'paragraphMedium'],
                 props?.className,
             ),
         },

--- a/src/stories/text/Text.tsx
+++ b/src/stories/text/Text.tsx
@@ -6,8 +6,9 @@ import styles from './Text.module.scss';
 import type { LightTheme } from '../theme';
 
 export type TextElement = 'p' | 'span' | 'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'label' | 'legend' | 'caption' | 'small';
-export type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 'normal' | 'bold' | 'lighter' | 'bolder' | 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset';
-export type FontStyle = 'normal' | 'italic' | 'oblique';
+export type GlobalCSSValues = 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset';
+export type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 'normal' | 'bold' | 'lighter' | 'bolder' | GlobalCSSValues;
+export type FontStyle = 'normal' | 'italic' | 'oblique' | GlobalCSSValues;
 
 export type TextProps<T extends TextElement = 'span'> = {
     /**

--- a/src/stories/text/Text.tsx
+++ b/src/stories/text/Text.tsx
@@ -70,9 +70,9 @@ export function Text<T extends TextElement>({
             ...props,
             className: clsx(
                 styles.text,
+                weight && styles[`weight-${weight}`],
+                fontStyle && styles[`fontStyle-${fontStyle}`],
                 typography[kind || 'paragraphMedium'],
-                weight && `weight-${weight}`,
-                fontStyle && `fontStyle-${fontStyle}`,
                 props?.className,
             ),
         },

--- a/src/stories/text/Typography.module.css
+++ b/src/stories/text/Typography.module.css
@@ -1,4 +1,4 @@
-/* Auto-generated with `pnpm generate:text` on Sat May 20 2023 19:55:10 GMT-0700 (Pacific Daylight Time) */
+/* Auto-generated with `pnpm generate:text` on Wed Jun 21 2023 15:22:53 GMT-0700 (Pacific Daylight Time) */
 /* Do not edit manually; instead, edit the `generateTextClasses` function in `scripts/text.ts` and run `pnpm generate:text -c`. */
 
 .displayLarge {

--- a/src/stories/theme/themes.ts
+++ b/src/stories/theme/themes.ts
@@ -119,7 +119,6 @@ export type Theme = {
     },
     typography: {
         fontFamily: string,
-        boldFontWeight: number,
         italicLetterSpacing: CSSLength,
         verticalMetricsAdjust: CSSLength;
 
@@ -339,7 +338,6 @@ export const LightTheme: Theme = {
     },
     typography: {
         fontFamily: '"Graphik Web", -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif',
-        boldFontWeight: 500,
         italicLetterSpacing: '-0.01em',
         verticalMetricsAdjust: '1px',
 

--- a/src/stories/theme/themes.ts
+++ b/src/stories/theme/themes.ts
@@ -123,6 +123,24 @@ export type Theme = {
         italicLetterSpacing: CSSLength,
         verticalMetricsAdjust: CSSLength;
 
+        fontWeights: {
+            thin: number,
+            extraLight: number,
+            light: number,
+            normal: number,
+            medium: number,
+            semiBold: number,
+            bold: number,
+            extraBold: number,
+            black: number,
+            extraBlack: number,
+        },
+
+        fontStyles: {
+            normal: string,
+            italic: string,
+        }
+
         styles: {
             // Display
 
@@ -324,6 +342,24 @@ export const LightTheme: Theme = {
         boldFontWeight: 500,
         italicLetterSpacing: '-0.01em',
         verticalMetricsAdjust: '1px',
+
+        fontWeights: {
+            thin: 100,
+            extraLight: 200,
+            light: 300,
+            normal: 400,
+            medium: 500,
+            semiBold: 600,
+            bold: 700,
+            extraBold: 800,
+            black: 900,
+            extraBlack: 950,
+        },
+
+        fontStyles: {
+            italic: 'italic',
+            normal: 'normal',
+        },
 
         styles: {
             // Display

--- a/src/stories/theme/util.scss
+++ b/src/stories/theme/util.scss
@@ -4,5 +4,5 @@
 }
 
 .bold {
-    font-weight: var(--pte-typography-boldFontWeight);
+    font-weight: var(--pte-typography-fontWeights-medium);
 }


### PR DESCRIPTION
This PR adds `weight` and `fontStyle` props to the Text component, and updates the story generator to generate specific prop configuration to show use case examples.

Specifically, we are adding theme variables for weight and fontStyle. The values set follow general standard, with the option of altering those semantic values from theme set up.

`weight` prop accepts all values as defined in our theme.
`fontStyle` prop accepts all values as defined in our theme.

`fontStyle` was used instead of `style` prop to not conflict inline `style` prop.
We also delete the use of `boldFontWeight` in favor of the fontWeights theme values.