### PR TITLE
Fix: tooltip hover

### DIFF
--- a/.changeset/quick-eagles-thank.md
+++ b/.changeset/quick-eagles-thank.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+InformationalTooltip: Removed `headingIcon` prop

--- a/.changeset/two-hats-sing.md
+++ b/.changeset/two-hats-sing.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+InformationalTooltip: Opens onClick for mobile support, new `disableClick` prop to disable that behavior

--- a/src/stories/informationaltooltip/InformationalTooltip.module.scss
+++ b/src/stories/informationaltooltip/InformationalTooltip.module.scss
@@ -20,5 +20,4 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    padding-left: 1px;
 }

--- a/src/stories/informationaltooltip/InformationalTooltip.stories.tsx
+++ b/src/stories/informationaltooltip/InformationalTooltip.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { createElement } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { InformationalTooltip } from './InformationalTooltip';
 
 const meta: Meta<typeof InformationalTooltip> = {
@@ -60,29 +58,6 @@ export const CustomAlign: Story = {
                 This tooltip below is set to align = `end`
             </div>
         ),
-    },
-    render,
-};
-
-export const HeadingIcon: Story = {
-    args: {
-        children: 'This is a medium tooltip with a heading',
-        size: 'medium',
-        headingIcon: (createElement(FontAwesomeIcon, {
-            icon: faPlus,
-            width: '14px',
-        })),
-        heading: 'Custom icon',
-    },
-    render,
-};
-
-export const NullIcon: Story = {
-    args: {
-        children: 'But the headingIcon is null',
-        size: 'medium',
-        headingIcon: null,
-        heading: 'This has a heading',
     },
     render,
 };

--- a/src/stories/informationaltooltip/InformationalTooltip.tsx
+++ b/src/stories/informationaltooltip/InformationalTooltip.tsx
@@ -19,8 +19,6 @@ export type InformationalTooltipProps = {
     trigger?: ReactNode;
     /** The heading text in the tooltip. If null, the heading will be hidden. */
     heading?: string | null;
-    /** The heading icon in the tooltip. If undefined, will show info icon. If pass in an element, it will display in the heading. If set to null, will hide icon. */
-    headingIcon?: ReactNode | null | undefined;
     /** The contents of the tooltip. */
     children?: ReactNode;
     /**
@@ -69,7 +67,6 @@ export const InformationalTooltip: FC<InformationalTooltipProps> = ({
     size = 'large',
     trigger,
     heading,
-    headingIcon,
     children,
     side = 'bottom',
     sideOffset = 6,
@@ -142,9 +139,6 @@ export const InformationalTooltip: FC<InformationalTooltipProps> = ({
                                 >
                                     {heading && (
                                         <div className={styles.heading}>
-                                            {headingIcon === null ? null : headingIcon || (
-                                                <Icon icon={Info} size={14} className={styles.icon} />
-                                            )}
                                             <TextWhenString as="p" kind="paragraphXSmall" weight="medium">
                                                 {heading}
                                             </TextWhenString>

--- a/src/stories/informationaltooltip/InformationalTooltip.tsx
+++ b/src/stories/informationaltooltip/InformationalTooltip.tsx
@@ -46,6 +46,11 @@ export type InformationalTooltipProps = {
      * @default false
      */
     defaultOpen?: boolean;
+    /**
+     * By default, tooltip opens on hover and on click (for mobile support). If you want to disable the click event, set this to true.
+     * @default false
+     */
+    disableClick?: boolean;
 };
 
 /**
@@ -70,6 +75,7 @@ export const InformationalTooltip: FC<InformationalTooltipProps> = ({
     sideOffset = 6,
     align = 'start',
     defaultOpen = false,
+    disableClick = false,
 }) => {
     const [isOpen, setOpen] = useState(defaultOpen);
 
@@ -104,7 +110,11 @@ export const InformationalTooltip: FC<InformationalTooltipProps> = ({
                 onOpenChange={setOpen}
             >
                 <RadixTooltip.Trigger
-                    onTouchStart={() => setOpen(!isOpen)}
+                    onClick={() => {
+                        if (!disableClick) {
+                            setOpen(!isOpen);
+                        }
+                    }}
                 >
                     {!trigger ? (
                         <Icon icon={Info} size={14} className={styles.icon} style={{ color: pvar('new.colors.contentSecondary') }} />

--- a/src/stories/informationaltooltip/InformationalTooltip.tsx
+++ b/src/stories/informationaltooltip/InformationalTooltip.tsx
@@ -104,7 +104,7 @@ export const InformationalTooltip: FC<InformationalTooltipProps> = ({
                 onOpenChange={setOpen}
             >
                 <RadixTooltip.Trigger
-                    onClick={() => setOpen(!isOpen)}
+                    onTouchStart={() => setOpen(!isOpen)}
                 >
                     {!trigger ? (
                         <Icon icon={Info} size={14} className={styles.icon} style={{ color: pvar('new.colors.contentSecondary') }} />

--- a/src/stories/informationaltooltip/InformationalTooltip.tsx
+++ b/src/stories/informationaltooltip/InformationalTooltip.tsx
@@ -103,7 +103,9 @@ export const InformationalTooltip: FC<InformationalTooltipProps> = ({
                 open={isOpen}
                 onOpenChange={setOpen}
             >
-                <RadixTooltip.Trigger>
+                <RadixTooltip.Trigger
+                    onClick={() => setOpen(!isOpen)}
+                >
                     {!trigger ? (
                         <Icon icon={Info} size={14} className={styles.icon} style={{ color: pvar('new.colors.contentSecondary') }} />
                     ) : (


### PR DESCRIPTION
* Added onClick to tooltip trigger for mobile support
* Added `disableClick` prop to optionally disable that behavior
* Removed headingIcon from tooltip (per Lily's change of mind)
* Closes ENG-1422