### PR TITLE
feat: headless v2 upgrade + switch

### DIFF
--- a/.changeset/cool-keys-clap.md
+++ b/.changeset/cool-keys-clap.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+Checkbox: new `switch` kind and `hideLabel` prop

--- a/.changeset/eleven-ads-drum.md
+++ b/.changeset/eleven-ads-drum.md
@@ -1,0 +1,5 @@
+---
+"paris": minor
+---
+
+Menu: refactored from dot notation to named exports, so new MenuButton, MenuItems, and MenuItem replaces Menu.Button, etc

--- a/.changeset/funny-carpets-decide.md
+++ b/.changeset/funny-carpets-decide.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+Select: multiselect listbox stays open for selecting multiple options

--- a/.changeset/gorgeous-needles-listen.md
+++ b/.changeset/gorgeous-needles-listen.md
@@ -2,4 +2,4 @@
 "paris": patch
 ---
 
-Combobox: optioins dropdown opens initially on focus, can disable with `hideOptionsInitially` prop
+Combobox: options dropdown opens initially on focus, can disable with `hideOptionsInitially` prop

--- a/.changeset/gorgeous-needles-listen.md
+++ b/.changeset/gorgeous-needles-listen.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+Combobox: optioins dropdown opens initially on focus, can disable with `hideOptionsInitially` prop

--- a/.changeset/slow-tips-sin.md
+++ b/.changeset/slow-tips-sin.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+General: upgraded headlessui package to v2

--- a/.changeset/two-eagles-invent.md
+++ b/.changeset/two-eagles-invent.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+Menu, Select, Combobox: dropdowns now render as modal, meaning page scroll is locked

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.2",
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "@headlessui/react": "^1.7.14",
+        "@headlessui/react": "^2.2.4",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.1.8",
         "clsx": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^0.2.0
     version: 0.2.0(@fortawesome/fontawesome-svg-core@6.4.2)(react@18.2.0)
   '@headlessui/react':
-    specifier: ^1.7.14
-    version: 1.7.14(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^2.2.4
+    version: 2.2.4(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-checkbox':
     specifier: ^1.0.4
     version: 1.0.4(@types/react-dom@18.2.8)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
@@ -2291,8 +2291,36 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
+  /@floating-ui/react-dom@2.1.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.5.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@floating-ui/react@0.26.28(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.2.0)(react@18.2.0)
+      '@floating-ui/utils': 0.2.9
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tabbable: 6.2.0
+    dev: false
+
   /@floating-ui/utils@0.1.6:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
+
+  /@floating-ui/utils@0.2.9:
+    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+    dev: false
 
   /@fortawesome/fontawesome-common-types@6.4.2:
     resolution: {integrity: sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==}
@@ -2335,16 +2363,20 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@headlessui/react@1.7.14(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-znzdq9PG8rkwcu9oQ2FwIy0ZFtP9Z7ycS+BAqJ3R5EIqC/0bJGvhT7193rFf+45i9nnPsYvCQVW4V/bB9Xc+gA==}
+  /@headlessui/react@2.2.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-lz+OGcAH1dK93rgSMzXmm1qKOJkBUqZf1L4M8TWLNplftQD3IkoEDdUFNfAn4ylsN6WOTVtWaLmvmaHOUk1dTA==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^16 || ^17 || ^18
-      react-dom: ^16 || ^17 || ^18
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
     dependencies:
-      client-only: 0.0.1
+      '@floating-ui/react': 0.26.28(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/focus': 3.20.3(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/interactions': 3.25.1(react-dom@18.2.0)(react@18.2.0)
+      '@tanstack/react-virtual': 3.13.9(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+      use-sync-external-store: 1.5.0(react@18.2.0)
     dev: false
 
   /@humanwhocodes/config-array@0.11.8:
@@ -2833,7 +2865,7 @@ packages:
   /@radix-ui/react-compose-refs@1.1.1(@types/react@18.2.8)(react@18.2.0):
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
-      '@types/react': 18.2.8
+      '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -2859,7 +2891,7 @@ packages:
   /@radix-ui/react-context@1.1.1(@types/react@18.2.8)(react@18.2.0):
     resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
     peerDependencies:
-      '@types/react': 18.2.8
+      '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -2987,7 +3019,7 @@ packages:
   /@radix-ui/react-id@1.1.0(@types/react@18.2.8)(react@18.2.0):
     resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
     peerDependencies:
-      '@types/react': 18.2.8
+      '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -3637,6 +3669,85 @@ packages:
 
   /@radix-ui/rect@1.1.0:
     resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
+    dev: false
+
+  /@react-aria/focus@3.20.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-rR5uZUMSY4xLHmpK/I8bP1V6vUNHFo33gTvrvNUsAKKqvMfa7R2nu5A6v97dr5g6tVH6xzpdkPsOJCWh90H2cw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/interactions': 3.25.1(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/utils': 3.29.0(react-dom@18.2.0)(react@18.2.0)
+      '@react-types/shared': 3.29.1(react@18.2.0)
+      '@swc/helpers': 0.5.1
+      clsx: 2.1.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@react-aria/interactions@3.25.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-ntLrlgqkmZupbbjekz3fE/n3eQH2vhncx8gUp0+N+GttKWevx7jos11JUBjnJwb1RSOPgRUFcrluOqBp0VgcfQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/ssr': 3.9.8(react@18.2.0)
+      '@react-aria/utils': 3.29.0(react-dom@18.2.0)(react@18.2.0)
+      '@react-stately/flags': 3.1.1
+      '@react-types/shared': 3.29.1(react@18.2.0)
+      '@swc/helpers': 0.5.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@react-aria/ssr@3.9.8(react@18.2.0):
+    resolution: {integrity: sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@swc/helpers': 0.5.1
+      react: 18.2.0
+    dev: false
+
+  /@react-aria/utils@3.29.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-jSOrZimCuT1iKNVlhjIxDkAhgF7HSp3pqyT6qjg/ZoA0wfqCi/okmrMPiWSAKBnkgX93N8GYTLT3CIEO6WZe9Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/ssr': 3.9.8(react@18.2.0)
+      '@react-stately/flags': 3.1.1
+      '@react-stately/utils': 3.10.6(react@18.2.0)
+      '@react-types/shared': 3.29.1(react@18.2.0)
+      '@swc/helpers': 0.5.1
+      clsx: 2.1.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@react-stately/flags@3.1.1:
+    resolution: {integrity: sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==}
+    dependencies:
+      '@swc/helpers': 0.5.1
+    dev: false
+
+  /@react-stately/utils@3.10.6(react@18.2.0):
+    resolution: {integrity: sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@swc/helpers': 0.5.1
+      react: 18.2.0
+    dev: false
+
+  /@react-types/shared@3.29.1(react@18.2.0):
+    resolution: {integrity: sha512-KtM+cDf2CXoUX439rfEhbnEdAgFZX20UP2A35ypNIawR7/PFFPjQDWyA2EnClCcW/dLWJDEPX2U8+EJff8xqmQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /@rushstack/eslint-patch@1.2.0:
@@ -5054,11 +5165,25 @@ packages:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.5.0
-    dev: true
 
   /@swc/types@0.1.5:
     resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
     dev: true
+
+  /@tanstack/react-virtual@3.13.9(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-SPWC8kwG/dWBf7Py7cfheAPOxuvIv4fFQ54PdmYbg7CpXfsKxkucak43Q0qKsxVthhUJQ1A7CIMAIplq4BjVwA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      '@tanstack/virtual-core': 3.13.9
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@tanstack/virtual-core@3.13.9:
+    resolution: {integrity: sha512-3jztt0jpaoJO5TARe2WIHC1UQC3VMLAFUW5mmMo0yrkwtDB2AQP0+sh10BVUpWrnvHjSLvzFizydtEGLCJKFoQ==}
+    dev: false
 
   /@testing-library/dom@9.3.3:
     resolution: {integrity: sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==}
@@ -6586,6 +6711,7 @@ packages:
 
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: true
 
   /cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
@@ -6628,6 +6754,11 @@ packages:
 
   /clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
     dev: false
 
@@ -12545,6 +12676,10 @@ packages:
       tslib: 2.5.0
     dev: true
 
+  /tabbable@6.2.0:
+    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+    dev: false
+
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -13214,6 +13349,14 @@ packages:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /use-sync-external-store@1.5.0(react@18.2.0):
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
       react: 18.2.0
     dev: false

--- a/src/stories/checkbox/Checkbox.module.scss
+++ b/src/stories/checkbox/Checkbox.module.scss
@@ -114,3 +114,47 @@
         color: var(--pte-new-colors-contentDisabled);
     }
 }
+
+.switchContainer {
+    width: 24px;
+    height: 14px;
+    border-radius: 100px;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    background-color: var(--pte-new-colors-contentTertiary);
+
+    &[data-headlessui-state="checked"], &[data-state="indeterminate"] {
+        background-color: var(--pte-new-colors-contentPrimary);
+    }
+
+    &[data-disabled=true] {
+        background-color: var(--pte-new-colors-contentInverseSecondary);
+
+        &[data-headlessui-state="checked"], &[data-state="indeterminate"] {
+            background-color: var(--pte-new-colors-contentInverseTertiary);
+        }
+    }
+
+    &:hover {
+        background-color: var(--pte-new-colors-contentSecondary);
+    }
+}
+
+.knob {
+    width: 10px;
+    height: 10px;
+    display: inline-block;
+    border-radius: 100%;
+
+    background-color: var(--pte-new-colors-contentInversePrimary);
+
+    transform: translateX(-5px);
+    transition: transform var(--pte-animations-interaction);
+}
+
+.knobChecked {
+    transform: translateX(5px);
+}

--- a/src/stories/checkbox/Checkbox.module.scss
+++ b/src/stories/checkbox/Checkbox.module.scss
@@ -126,14 +126,14 @@
 
     background-color: var(--pte-new-colors-contentTertiary);
 
-    &[data-headlessui-state="checked"], &[data-state="indeterminate"] {
+    &[data-checked], &[data-state="indeterminate"] {
         background-color: var(--pte-new-colors-contentPrimary);
     }
 
     &[data-disabled=true] {
         background-color: var(--pte-new-colors-contentInverseSecondary);
 
-        &[data-headlessui-state="checked"], &[data-state="indeterminate"] {
+        &[data-checked], &[data-state="indeterminate"] {
             background-color: var(--pte-new-colors-contentInverseTertiary);
         }
     }

--- a/src/stories/checkbox/Checkbox.stories.ts
+++ b/src/stories/checkbox/Checkbox.stories.ts
@@ -41,3 +41,36 @@ export const Surface: Story = {
         });
     },
 };
+
+export const Switch: Story = {
+    args: {
+        children: 'ACH Bank Transfer',
+        kind: 'switch',
+    },
+    render: (args) => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [checked, setChecked] = useState(false);
+        return createElement(Checkbox, {
+            ...args,
+            checked,
+            onChange: (e) => setChecked(!!e),
+        });
+    },
+};
+
+export const HideLabel: Story = {
+    args: {
+        children: 'ACH Bank Transfer',
+        kind: 'switch',
+        hideLabel: true,
+    },
+    render: (args) => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [checked, setChecked] = useState(false);
+        return createElement(Checkbox, {
+            ...args,
+            checked,
+            onChange: (e) => setChecked(!!e),
+        });
+    },
+};

--- a/src/stories/checkbox/Checkbox.tsx
+++ b/src/stories/checkbox/Checkbox.tsx
@@ -1,18 +1,24 @@
 import type { FC, ReactNode } from 'react';
-import { useRef, useId } from 'react';
+import { useId } from 'react';
 import * as RadixCheckbox from '@radix-ui/react-checkbox';
 import clsx from 'clsx';
+import { Switch } from '@headlessui/react';
 import styles from './Checkbox.module.scss';
-import { pvar } from '../theme';
-import { TextWhenString } from '../utility';
+import { TextWhenString, VisuallyHidden } from '../utility';
 import { Check, Icon } from '../icon';
 
 export type CheckboxProps = {
-    /** The visual style of the Checkbox. `default` is a standard checkbox with a label next to it, `surface` is a clickable card that displays a check when selected.  */
-    kind?: 'default' | 'surface'
+    /** The visual style of the Checkbox. `default` is a standard checkbox with a label next to it, `surface` is a clickable card that displays a check when selected, `switch` is a switch toggle.  */
+    kind?: 'default' | 'surface' | 'switch'
     checked?: boolean;
     onChange?: (checked: boolean | 'indeterminate') => void;
     disabled?: boolean;
+    /**
+     * Whether to hide the label text of the Checkbox. Does not apply to `kind="surface"` because there would be nothing visible.
+     *
+     * @default false
+     */
+    hideLabel?: boolean;
     /** The contents of the Checkbox. */
     children?: ReactNode | ReactNode[];
 } & Omit<React.ComponentPropsWithoutRef<'label'>, 'onChange' | 'children'>;
@@ -34,6 +40,7 @@ export const Checkbox: FC<CheckboxProps> = ({
     checked,
     onChange,
     disabled,
+    hideLabel = false,
     children,
     className,
     ...props
@@ -45,42 +52,67 @@ export const Checkbox: FC<CheckboxProps> = ({
             className={clsx(styles.container, disabled && styles.disabled, className, checked && styles.checked)}
             {...props}
         >
-            <RadixCheckbox.Root
-                id={inputID}
-                className={clsx(styles.root, styles[kind])}
-                checked={checked}
-                onCheckedChange={onChange}
-                data-disabled={disabled}
-            >
-                {kind === 'surface' && (
-                    <TextWhenString kind="paragraphXSmall">
-                        {children}
-                    </TextWhenString>
-                )}
-                <RadixCheckbox.Indicator className={styles.indicator}>
-                    {kind === 'default' && (
-                        <svg width={14} height={14} viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path
-                                className={styles.checkSvg}
-                                data-disabled={disabled}
-                                d="M0.333374 0.333252V13.6666H13.6667V0.333252H0.333374ZM6.00004 10.3999L2.26672 6.66658L3.66671 5.26658L5.93339 7.53325L10.2 3.26658L11.6001 4.66659L6.00004 10.3999Z"
-                            />
-                        </svg>
-                    )}
+            {(kind === 'default' || kind === 'surface') && (
+                <RadixCheckbox.Root
+                    id={inputID}
+                    className={clsx(styles.root, styles[kind])}
+                    checked={checked}
+                    onCheckedChange={onChange}
+                    data-disabled={disabled}
+                    aria-details={typeof children === 'string' ? children : undefined}
+                >
                     {kind === 'surface' && (
-                        <Icon
-                            icon={Check}
-                            size={12.8}
-                            data-disabled={disabled}
-                            className={styles.checkIcon}
-                        />
+                        <TextWhenString kind="paragraphXSmall">
+                            {children}
+                        </TextWhenString>
                     )}
-                </RadixCheckbox.Indicator>
-            </RadixCheckbox.Root>
-            {kind === 'default' && (
+                    <RadixCheckbox.Indicator className={styles.indicator}>
+                        {kind === 'default' && (
+                            <svg width={14} height={14} viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path
+                                    className={styles.checkSvg}
+                                    data-disabled={disabled}
+                                    d="M0.333374 0.333252V13.6666H13.6667V0.333252H0.333374ZM6.00004 10.3999L2.26672 6.66658L3.66671 5.26658L5.93339 7.53325L10.2 3.26658L11.6001 4.66659L6.00004 10.3999Z"
+                                />
+                            </svg>
+                        )}
+                        {kind === 'surface' && (
+                            <Icon
+                                icon={Check}
+                                size={12.8}
+                                data-disabled={disabled}
+                                className={styles.checkIcon}
+                            />
+                        )}
+                    </RadixCheckbox.Indicator>
+                </RadixCheckbox.Root>
+            )}
+            {kind === 'switch' && (
+                <>
+                    <Switch
+                        checked={checked}
+                        onChange={onChange}
+                        className={styles.switchContainer}
+                        data-disabled={disabled}
+                        id={inputID}
+                        aria-details={typeof children === 'string' ? children : undefined}
+                    >
+                        <span
+                            aria-hidden="true"
+                            className={clsx(styles.knob, checked && styles.knobChecked)}
+                        />
+                    </Switch>
+                </>
+            )}
+            {(kind === 'default' || kind === 'switch') && !hideLabel && (
                 <TextWhenString kind="paragraphXSmall">
                     {children}
                 </TextWhenString>
+            )}
+            {hideLabel && (
+                <VisuallyHidden>
+                    {children}
+                </VisuallyHidden>
             )}
         </label>
     );

--- a/src/stories/combobox/Combobox.stories.ts
+++ b/src/stories/combobox/Combobox.stories.ts
@@ -59,6 +59,42 @@ const ComboboxArgs: ComboboxProps<{ name: string }> = {
     ],
 };
 
+const ComboboxArgs2: ComboboxProps<{ name: string }> = {
+    label: 'Share',
+    description: 'Search for a friend to share this document with.',
+    placeholder: 'Search...',
+    options: [
+        {
+            id: '1',
+            node: 'Mia Dolan',
+            metadata: {
+                name: 'Mia Dolan',
+            },
+        },
+        {
+            id: '2',
+            node: 'SEB',
+            metadata: {
+                name: 'Sebastian Wilder',
+            },
+        },
+        {
+            id: '3',
+            node: 'Amy Brandt',
+            metadata: {
+                name: 'Amy Brandt',
+            },
+        },
+        {
+            id: '4',
+            node: 'Laura Wilder',
+            metadata: {
+                name: 'Laura Wilder',
+            },
+        },
+    ],
+};
+
 export const Default: Story = {
     args: ComboboxArgs,
     render: (args) => {
@@ -101,6 +137,54 @@ export const AllowCustomValue: Story = {
             options: (args.options as Option<{ name: string }>[]).filter((o) => (o.metadata?.name as string || '').toLowerCase().includes(inputValue.toLowerCase())),
             onChange: (e) => setSelected(e),
             onInputChange: (e) => setInputValue(e),
+        }));
+    },
+};
+
+export const HideOptionsInitially: Story = {
+    args: ComboboxArgs,
+    render: (args) => {
+        const [selected, setSelected] = useState<Option<{ name: string }> | null>(null);
+        const [inputValue, setInputValue] = useState<string>('');
+        return createElement('div', {
+            style: { minHeight: '200px' },
+        }, createElement(Combobox<{ name: string }>, {
+            ...args,
+            value: (selected?.id === null) ? {
+                id: null,
+                node: inputValue,
+                metadata: {
+                    name: inputValue,
+                },
+            } : selected as Option<{ name: string }> | null,
+            options: (args.options as Option<{ name: string }>[]).filter((o) => (o.metadata?.name as string || '').toLowerCase().includes(inputValue.toLowerCase())),
+            onChange: (e) => setSelected(e),
+            onInputChange: (e) => setInputValue(e),
+            hideOptionsInitially: true,
+        }));
+    },
+};
+
+export const HideClearButton: Story = {
+    args: ComboboxArgs2,
+    render: (args) => {
+        const [selected, setSelected] = useState<Option<{ name: string }> | null>(null);
+        const [inputValue, setInputValue] = useState<string>('');
+        return createElement('div', {
+            style: { minHeight: '200px' },
+        }, createElement(Combobox<{ name: string }>, {
+            ...args,
+            value: (selected?.id === null) ? {
+                id: null,
+                node: inputValue,
+                metadata: {
+                    name: inputValue,
+                },
+            } : selected as Option<{ name: string }> | null,
+            options: (args.options as Option<{ name: string }>[]).filter((o) => (o.metadata?.name as string || '').toLowerCase().includes(inputValue.toLowerCase())),
+            onChange: (e) => setSelected(e),
+            onInputChange: (e) => setInputValue(e),
+            hideClearButton: true,
         }));
     },
 };

--- a/src/stories/combobox/Combobox.tsx
+++ b/src/stories/combobox/Combobox.tsx
@@ -2,11 +2,11 @@
 
 import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from 'react';
 import {
-    Fragment,
-
     useMemo, useId, useState,
 } from 'react';
-import { Combobox as HCombobox, Transition } from '@headlessui/react';
+import {
+    Combobox as HCombobox, ComboboxInput, ComboboxOptions, ComboboxOption, Transition,
+} from '@headlessui/react';
 import clsx from 'clsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClose } from '@fortawesome/free-solid-svg-icons';
@@ -98,6 +98,11 @@ export type ComboboxProps<T extends Record<string, any>> = {
      */
     hasOptionBorder?: boolean;
     /**
+     * Whether the dropdown should open immediately when focused, vs only after starting to type.
+     * @default false
+     */
+    hideOptionsInitially?: boolean;
+    /**
      * Prop overrides for other rendered elements. Overrides for the input itself should be passed directly to the component.
      */
     overrides?: {
@@ -153,6 +158,7 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
     hideClearButton = false,
     maxHeight = 320,
     hasOptionBorder = false,
+    hideOptionsInitially = false,
     overrides,
 }: ComboboxProps<T>) {
     const inputID = useId();
@@ -184,6 +190,7 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
         >
             <HCombobox
                 as="div"
+                immediate={!hideOptionsInitially}
                 value={selectedID}
                 onChange={(id) => {
                     if (onChange) {
@@ -224,7 +231,7 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
                     )}
                     <div className={styles.content}>
                         {(value?.node && typeof value.node !== 'string') ? value.node : (
-                            <HCombobox.Input
+                            <ComboboxInput
                                 id={inputID}
                                 {...overrides?.input}
                                 placeholder={placeholder}
@@ -293,7 +300,8 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
                     leaveFrom={dropdownStyles.leaveFrom}
                     leaveTo={dropdownStyles.leaveTo}
                 >
-                    <HCombobox.Options
+                    <ComboboxOptions
+                        as="ul"
                         {...overrides?.optionsContainer}
                         className={clsx(
                             overrides?.optionsContainer?.className,
@@ -305,7 +313,8 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
                         } as CSSProperties}
                     >
                         {(allowCustomValue && showCustomValueOption && !customValueToOption && query.length > 0) && (
-                            <HCombobox.Option
+                            <ComboboxOption
+                                as="li"
                                 value={query}
                                 data-selected={false}
                                 className={clsx(
@@ -317,14 +326,15 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
                                 <Text as="span" kind="paragraphSmall">
                                     {customValueString.replace('%v', query)}
                                 </Text>
-                            </HCombobox.Option>
+                            </ComboboxOption>
                         )}
                         {
                             (
                                 optionsWithCustomValue || []
                             )
                                 .map((option) => (
-                                    <HCombobox.Option
+                                    <ComboboxOption
+                                        as="li"
                                         key={option.id}
                                         value={option.id}
                                         {...overrides?.option}
@@ -338,10 +348,10 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
                                         <TextWhenString as="span" kind="paragraphSmall">
                                             {option.node}
                                         </TextWhenString>
-                                    </HCombobox.Option>
+                                    </ComboboxOption>
                                 ))
                         }
-                    </HCombobox.Options>
+                    </ComboboxOptions>
                 </Transition>
             </HCombobox>
         </Field>

--- a/src/stories/combobox/Combobox.tsx
+++ b/src/stories/combobox/Combobox.tsx
@@ -23,6 +23,7 @@ import { Field } from '../field';
 import type { ButtonProps } from '../button';
 import { Button } from '../button';
 import { TextWhenString } from '../utility';
+import { Check, Icon } from '../icon';
 
 export type Option<T extends Record<string, any> = Record<string, any>> = {
     id: string,
@@ -338,7 +339,6 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
                                         key={option.id}
                                         value={option.id}
                                         {...overrides?.option}
-                                        data-selected={option.id === value}
                                         className={clsx(
                                             overrides?.option?.className,
                                             styles.option,

--- a/src/stories/dialog/Dialog.module.scss
+++ b/src/stories/dialog/Dialog.module.scss
@@ -17,7 +17,7 @@ $panelAnimationDelay: var(--pte-animations-duration-fast);
     transition: var(--pte-animations-duration-normal) var(--pte-animations-timing-easeInOut);
 
     &.overlayBlur {
-        backdrop-filter: blur(0);
+        backdrop-filter: blur(2px);
         background-color: var(--pte-new-colors-overlayPageBackground);
         will-change: backdrop-filter, opacity;
     }

--- a/src/stories/dialog/Dialog.tsx
+++ b/src/stories/dialog/Dialog.tsx
@@ -3,8 +3,10 @@
 import type {
     ComponentPropsWithoutRef, FC, MouseEventHandler, PropsWithChildren, ReactNode,
 } from 'react';
-import { Fragment, useEffect, useState } from 'react';
-import { Dialog as HDialog, Transition } from '@headlessui/react';
+import { useEffect, useState } from 'react';
+import {
+    Dialog as HDialog, DialogPanel, DialogTitle, Transition, TransitionChild,
+} from '@headlessui/react';
 import clsx from 'clsx';
 import styles from './Dialog.module.scss';
 import { Text } from '../text';
@@ -166,7 +168,6 @@ export const Dialog: FC<PropsWithChildren<DialogProps>> = ({
         <Transition
             appear
             show={isOpen}
-            as={Fragment}
         >
             <HDialog
                 as="div"
@@ -176,8 +177,9 @@ export const Dialog: FC<PropsWithChildren<DialogProps>> = ({
                     styles.root,
                     overrides.root?.className,
                 )}
+                role="dialog"
             >
-                <HDialog.Overlay
+                <div
                     {...overrides.overlayContainer}
                     className={clsx(
                         overlayStyle === 'blur' && styles.overlayBlurContainer,
@@ -185,8 +187,7 @@ export const Dialog: FC<PropsWithChildren<DialogProps>> = ({
                         overrides.overlayContainer?.className,
                     )}
                 >
-                    <Transition.Child
-                        as={Fragment}
+                    <TransitionChild
                         enter={styles.enter}
                         enterFrom={styles.enterFrom}
                         enterTo={styles.enterTo}
@@ -203,8 +204,8 @@ export const Dialog: FC<PropsWithChildren<DialogProps>> = ({
                                 overrides.overlay?.className,
                             )}
                         />
-                    </Transition.Child>
-                </HDialog.Overlay>
+                    </TransitionChild>
+                </div>
 
                 <div
                     {...overrides.panelContainer}
@@ -213,8 +214,7 @@ export const Dialog: FC<PropsWithChildren<DialogProps>> = ({
                         overrides.panelContainer?.className,
                     )}
                 >
-                    <Transition.Child
-                        as={Fragment}
+                    <TransitionChild
                         enter={styles.enter}
                         enterFrom={styles.enterFrom}
                         enterTo={styles.enterTo}
@@ -222,7 +222,7 @@ export const Dialog: FC<PropsWithChildren<DialogProps>> = ({
                         leaveFrom={styles.leaveFrom}
                         leaveTo={styles.leaveTo}
                     >
-                        <HDialog.Panel
+                        <DialogPanel
                             {...overrides.panel}
                             className={clsx(
                                 styles.panel,
@@ -248,7 +248,7 @@ export const Dialog: FC<PropsWithChildren<DialogProps>> = ({
                                     } : {}}
                                 >
                                     <VisuallyHidden when={hideTitle}>
-                                        <HDialog.Title
+                                        <DialogTitle
                                             {...overrides.panelTitle}
                                             as="h1"
                                             className={clsx(
@@ -261,7 +261,7 @@ export const Dialog: FC<PropsWithChildren<DialogProps>> = ({
                                             >
                                                 {title}
                                             </TextWhenString>
-                                        </HDialog.Title>
+                                        </DialogTitle>
                                     </VisuallyHidden>
                                     <RemoveFromDOM when={hideCloseButton}>
                                         <div className={clsx(styles.closeButton)}>
@@ -285,8 +285,8 @@ export const Dialog: FC<PropsWithChildren<DialogProps>> = ({
                                 </div>
                             </VisuallyHidden>
                             {children}
-                        </HDialog.Panel>
-                    </Transition.Child>
+                        </DialogPanel>
+                    </TransitionChild>
                 </div>
             </HDialog>
         </Transition>

--- a/src/stories/drawer/Drawer.module.scss
+++ b/src/stories/drawer/Drawer.module.scss
@@ -27,7 +27,7 @@ $panelAnimationDelay: var(--pte-animations-duration-fast);
     inset: 0;
 
     &.overlayBlur {
-        backdrop-filter: blur(0);
+        backdrop-filter: blur(2px);
         background-color: var(--pte-new-colors-overlayPageBackground);
         will-change: backdrop-filter, opacity;
     }

--- a/src/stories/drawer/Drawer.stories.tsx
+++ b/src/stories/drawer/Drawer.stories.tsx
@@ -6,7 +6,7 @@ import { Drawer } from './Drawer';
 import { Button } from '../button';
 import { Callout } from '../callout';
 import {
-    Menu,
+    Menu, MenuButton, MenuItems, MenuItem,
 } from '../menu';
 import { usePagination } from '../pagination';
 import { ChevronRight, Ellipsis } from '../icon';
@@ -41,7 +41,7 @@ export const Default: Story = {
                     onClose={setIsOpen}
                     additionalActions={(
                         <Menu as="div">
-                            <Menu.Button>
+                            <MenuButton>
                                 <Button
                                     kind="tertiary"
                                     shape="circle"
@@ -51,16 +51,16 @@ export const Default: Story = {
                                 >
                                     Action menu
                                 </Button>
-                            </Menu.Button>
-                            <Menu.Items position="right">
-                                <Menu.Item as="button">
+                            </MenuButton>
+                            <MenuItems position="right">
+                                <MenuItem as="button">
                                     Dispute
-                                </Menu.Item>
-                                <Menu.Item as="button">
+                                </MenuItem>
+                                <MenuItem as="button">
                                     Transfer
                                     <ChevronRight size={20} />
-                                </Menu.Item>
-                            </Menu.Items>
+                                </MenuItem>
+                            </MenuItems>
                         </Menu>
                     )}
                 >
@@ -101,7 +101,7 @@ export const Paginated: Story = {
                     title={currentPageTitle}
                     additionalActions={(
                         <Menu as="div">
-                            <Menu.Button>
+                            <MenuButton>
                                 <Button
                                     kind="tertiary"
                                     shape="circle"
@@ -111,16 +111,16 @@ export const Paginated: Story = {
                                 >
                                     Action menu
                                 </Button>
-                            </Menu.Button>
-                            <Menu.Items position="right">
-                                <Menu.Item as="button">
+                            </MenuButton>
+                            <MenuItems position="right">
+                                <MenuItem as="button">
                                     Dispute
-                                </Menu.Item>
-                                <Menu.Item as="button">
+                                </MenuItem>
+                                <MenuItem as="button">
                                     Transfer
                                     <ChevronRight size={20} />
-                                </Menu.Item>
-                            </Menu.Items>
+                                </MenuItem>
+                            </MenuItems>
                         </Menu>
                     )}
                 >
@@ -222,7 +222,7 @@ export const BottomPanel: Story = {
                     onClose={setIsOpen}
                     additionalActions={(
                         <Menu as="div">
-                            <Menu.Button>
+                            <MenuButton>
                                 <Button
                                     kind="tertiary"
                                     shape="circle"
@@ -232,16 +232,16 @@ export const BottomPanel: Story = {
                                 >
                                     Action menu
                                 </Button>
-                            </Menu.Button>
-                            <Menu.Items position="right">
-                                <Menu.Item as="button">
+                            </MenuButton>
+                            <MenuItems position="right">
+                                <MenuItem as="button">
                                     Dispute
-                                </Menu.Item>
-                                <Menu.Item as="button">
+                                </MenuItem>
+                                <MenuItem as="button">
                                     Transfer
                                     <ChevronRight size={20} />
-                                </Menu.Item>
-                            </Menu.Items>
+                                </MenuItem>
+                            </MenuItems>
                         </Menu>
                     )}
                 >

--- a/src/stories/drawer/Drawer.tsx
+++ b/src/stories/drawer/Drawer.tsx
@@ -2,10 +2,11 @@
 
 import type { ReactNode, ComponentPropsWithoutRef } from 'react';
 import {
-    useEffect,
-    useRef, Fragment, useMemo, useState,
+    useMemo, useState,
 } from 'react';
-import { Dialog, Transition } from '@headlessui/react';
+import {
+    Dialog, DialogPanel, DialogTitle, Transition, TransitionChild,
+} from '@headlessui/react';
 import clsx from 'clsx';
 import type { CSSLength } from '@ssh/csstypes';
 import styles from './Drawer.module.scss';
@@ -205,7 +206,7 @@ export const Drawer = <T extends string[] | readonly string[] = string[]>({
     }, [children, pagination]);
 
     return (
-        <Transition show={isOpen} as={Fragment}>
+        <Transition show={isOpen}>
             <Dialog
                 as="div"
                 className={clsx(
@@ -214,6 +215,7 @@ export const Drawer = <T extends string[] | readonly string[] = string[]>({
                 )}
                 onClose={onClose}
                 {...overrides?.dialog}
+                role="dialog"
             >
                 <div
                     className={clsx(
@@ -222,8 +224,7 @@ export const Drawer = <T extends string[] | readonly string[] = string[]>({
                         overrides?.overlay?.className,
                     )}
                 >
-                    <Transition.Child
-                        as={Fragment}
+                    <TransitionChild
                         enter={styles.enter}
                         enterFrom={styles.enterFrom}
                         enterTo={styles.enterTo}
@@ -231,14 +232,14 @@ export const Drawer = <T extends string[] | readonly string[] = string[]>({
                         leaveFrom={styles.leaveFrom}
                         leaveTo={styles.leaveTo}
                     >
-                        <Dialog.Overlay
+                        <div
                             className={clsx(
                                 styles.overlay,
                                 overlayStyle === 'blur' && styles.overlayBlur,
                                 overlayStyle === 'grey' && styles.overlayGrey,
                             )}
                         />
-                    </Transition.Child>
+                    </TransitionChild>
                 </div>
 
                 <div
@@ -254,8 +255,7 @@ export const Drawer = <T extends string[] | readonly string[] = string[]>({
                     } : overrides?.panelContainer?.style}
                     {...overrides?.panelContainer}
                 >
-                    <Transition.Child
-                        as={Fragment}
+                    <TransitionChild
                         enter={styles.enter}
                         enterFrom={styles.enterFrom}
                         enterTo={styles.enterTo}
@@ -263,7 +263,7 @@ export const Drawer = <T extends string[] | readonly string[] = string[]>({
                         leaveFrom={styles.leaveFrom}
                         leaveTo={styles.leaveTo}
                     >
-                        <Dialog.Panel
+                        <DialogPanel
                             className={clsx(
                                 styles.panel,
                                 styles[`from-${from}`],
@@ -316,11 +316,11 @@ export const Drawer = <T extends string[] | readonly string[] = string[]>({
                                         // Hide when requested, or when pagination is enabled (the title isn't relevant to any specific page).
                                         when={hideTitle}
                                     >
-                                        <Dialog.Title as="h2" className={styles.titleTextContainer}>
+                                        <DialogTitle as="h2" className={styles.titleTextContainer}>
                                             <TextWhenString kind="paragraphSmall" weight="medium">
                                                 {title}
                                             </TextWhenString>
-                                        </Dialog.Title>
+                                        </DialogTitle>
                                     </VisuallyHidden>
                                 </div>
                                 <div className={clsx(styles.titleBarButtons, overrides?.titleBarButtons?.className)}>
@@ -389,8 +389,8 @@ export const Drawer = <T extends string[] | readonly string[] = string[]>({
                                     </>
                                 )}
                             </div>
-                        </Dialog.Panel>
-                    </Transition.Child>
+                        </DialogPanel>
+                    </TransitionChild>
                 </div>
             </Dialog>
         </Transition>

--- a/src/stories/menu/Menu.stories.tsx
+++ b/src/stories/menu/Menu.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import {
-    Menu,
+    Menu, MenuButton, MenuItems, MenuItem,
 } from './Menu';
 import { Button } from '../button';
 import { ChevronRight, Ellipsis } from '../icon';
@@ -21,7 +21,7 @@ export const Default: Story = {
     render: (args) => (
         <div style={{ height: '150px' }}>
             <Menu as="div">
-                <Menu.Button>
+                <MenuButton>
                     <Button
                         kind="tertiary"
                         shape="circle"
@@ -31,16 +31,16 @@ export const Default: Story = {
                     >
                         Action menu
                     </Button>
-                </Menu.Button>
-                <Menu.Items>
-                    <Menu.Item as="button">
+                </MenuButton>
+                <MenuItems>
+                    <MenuItem as="button">
                         Dispute
-                    </Menu.Item>
-                    <Menu.Item as="button">
+                    </MenuItem>
+                    <MenuItem as="button">
                         Transfer
                         <ChevronRight size={20} />
-                    </Menu.Item>
-                </Menu.Items>
+                    </MenuItem>
+                </MenuItems>
             </Menu>
         </div>
     ),

--- a/src/stories/menu/Menu.tsx
+++ b/src/stories/menu/Menu.tsx
@@ -1,42 +1,33 @@
 import type { FC } from 'react';
-import { Fragment, ReactNode } from 'react';
 import type {
     MenuProps, MenuItemsProps, MenuItemProps, MenuButtonProps,
 } from '@headlessui/react';
-import { Menu as HeadlessMenu, Transition } from '@headlessui/react';
+import {
+    Menu as HeadlessMenu, MenuButton as HMenuButton, MenuItems as HMenuItems, MenuItem as HMenuItem, Transition,
+} from '@headlessui/react';
 import clsx from 'clsx';
 
 import styles from './Menu.module.scss';
 import dropdownStyles from '../utility/Dropdown.module.scss';
 
-export { Menu as HeadlessMenu } from '@headlessui/react';
-
 /**
  * Wraps the `HeadlessMenu` component from `@headlessui/react` to provide a styled dropdown menu.
  *
- * This component serves as the root of the menu and should wrap `Menu.Button`, `Menu.Items`, and `Menu.Item` components.
+ * This component serves as the root of the menu and should wrap `MenuButton`, `MenuItems`, and `MenuItem` components.
  *
  * Usage:
  *
  * ```tsx
  * <Menu>
- *   <Menu.Button>Options</Menu.Button>
- *   <Menu.Items>
- *     <Menu.Item>Item 1</Menu.Item>
- *     <Menu.Item>Item 2</Menu.Item>
- *   </Menu.Items>
+ *   <MenuButton>Options</MenuButton>
+ *   <MenuItems>
+ *     <MenuItem>Item 1</MenuItem>
+ *     <MenuItem>Item 2</MenuItem>
+ *   </MenuItems>
  * </Menu>
  * ```
  */
-export const Menu: FC<MenuProps<React.ElementType>> & {
-    Button: FC<MenuButtonProps<React.ElementType>>;
-    Items: FC<MenuItemsProps<React.ElementType> & {
-        position?: 'left' | 'right';
-    }>;
-    Item: FC<MenuItemProps<React.ElementType> & {
-        isNew?: boolean;
-    }>;
-} = ({ className, children, ...props }) => (
+export const Menu: FC<MenuProps<React.ElementType>> = ({ className, children, ...props }) => (
     <HeadlessMenu as="div" className={clsx(styles.menu, className)} {...props}>
         {children}
     </HeadlessMenu>
@@ -47,10 +38,10 @@ export const Menu: FC<MenuProps<React.ElementType>> & {
  *
  * Should be used inside a `Menu` component to serve as the toggle for `MenuItems`.
  */
-Menu.Button = ({ className, children, ...props }) => (
-    <HeadlessMenu.Button className={clsx(styles.menuButton, className)} {...props}>
+export const MenuButton: FC<MenuButtonProps<React.ElementType>> = ({ className, children, ...props }) => (
+    <HMenuButton className={clsx(styles.menuButton, className)} {...props}>
         {children}
-    </HeadlessMenu.Button>
+    </HMenuButton>
 );
 
 /**
@@ -60,7 +51,9 @@ Menu.Button = ({ className, children, ...props }) => (
  *
  * @param position - Controls the positioning of the menu items ('left' or 'right').
  */
-Menu.Items = ({
+export const MenuItems: FC<MenuItemsProps<React.ElementType> & {
+    position?: 'left' | 'right';
+}> = ({
     className, children, position = 'left', ...props
 }) => (
     <Transition
@@ -73,9 +66,9 @@ Menu.Items = ({
         leaveFrom={dropdownStyles.leaveFrom}
         leaveTo={dropdownStyles.leaveTo}
     >
-        <HeadlessMenu.Items className={clsx(styles.menuItems, position === 'left' && styles.leftPosition, position === 'right' && styles.rightPosition, className)} {...props}>
+        <HMenuItems className={clsx(styles.menuItems, position === 'left' && styles.leftPosition, position === 'right' && styles.rightPosition, className)} {...props}>
             {children}
-        </HeadlessMenu.Items>
+        </HMenuItems>
     </Transition>
 );
 
@@ -86,10 +79,12 @@ Menu.Items = ({
  *
  * @param isNew - Whether the menu items should be styled as new items.
  */
-Menu.Item = ({
+export const MenuItem: FC<MenuItemProps<React.ElementType> & {
+    isNew?: boolean;
+}> = ({
     className, children, isNew = false, ...props
 }) => (
-    <HeadlessMenu.Item className={clsx(styles.menuItem, isNew && styles.newItem, className)} {...props}>
+    <HMenuItem className={clsx(styles.menuItem, isNew && styles.newItem, className)} {...props}>
         {children}
-    </HeadlessMenu.Item>
+    </HMenuItem>
 );

--- a/src/stories/select/Select.module.scss
+++ b/src/stories/select/Select.module.scss
@@ -66,15 +66,15 @@
 
     transition: var(--pte-animations-interaction);
 
-    &[data-selected=true] {
+    &[data-selected] {
         background-color: var(--pte-new-colors-overlaySubtle);
     }
 
-    &:hover, &[data-headlessui-state="active"] {
+    &:hover, &[data-active], &[data-focus] {
         background-color: var(--pte-new-colors-overlayMedium);
     }
 
-    &[data-status="disabled"], &[data-headlessui-state~="disabled"] {
+    &[data-status="disabled"], &[data-disabled] {
         pointer-events: none;
         cursor: default;
 
@@ -110,19 +110,19 @@
     justify-content: flex-start;
     align-items: center;
 
-    &[data-headlessui-state~="active"] {
+    &[data-focus] {
         .radioCircle {
             border-color: var(--pte-new-colors-contentPrimary);
         }
     }
 
-    &[data-headlessui-state~="checked"] {
+    &[data-checked] {
         .radioCircle {
             border: 5px solid var(--pte-new-colors-contentPrimary);
         }
     }
 
-    &[data-status="disabled"], &[data-headlessui-state~="disabled"] {
+    &[data-status="disabled"], &[data-disabled] {
         pointer-events: none;
         cursor: default;
 
@@ -171,21 +171,21 @@
     border-radius: 6px;
     width: 100%;
 
-    &[data-headlessui-state~="active"] {
+    &[data-focus] {
         //.cardSurface {
         //    background-color: var(--pte-new-colors-overlayWhiteSubtle);
         //    border-color: var(--pte-new-colors-borderStrong);
         //}
     }
 
-    &[data-headlessui-state~="checked"] {
+    &[data-checked] {
         .cardSurface {
             background-color: var(--pte-new-colors-overlayMedium);
             border-color: var(--pte-new-colors-borderUltrastrong);
         }
     }
 
-    &[data-status="disabled"], &[data-headlessui-state~="disabled"] {
+    &[data-status="disabled"], &[data-disabled] {
         pointer-events: none;
         cursor: default;
 
@@ -262,11 +262,7 @@
         padding: 6px 20px;
     }
 
-    &[data-headlessui-state~="active"] {
-
-    }
-
-    &[data-status="disabled"], &[data-headlessui-state~="disabled"] {
+    &[data-status="disabled"], &[data-disabled] {
         pointer-events: none;
         cursor: default;
 
@@ -284,7 +280,7 @@
         color: var(--pte-new-colors-contentPrimary);
     }
 
-    &[data-headlessui-state~="checked"] {
+    &[data-checked] {
         color: var(--pte-new-colors-contentPrimary);
     }
 }

--- a/src/stories/select/Select.stories.ts
+++ b/src/stories/select/Select.stories.ts
@@ -133,7 +133,7 @@ export const Multiple: Story = {
     },
     render,
 };
-      
+
 export const Segmented: Story = {
     args: {
         label: 'Donation',

--- a/src/stories/select/Select.tsx
+++ b/src/stories/select/Select.tsx
@@ -256,7 +256,6 @@ export const Select = forwardRef(function <T = Record<string, any>>({
                                 <ListboxOption
                                     key={option.id}
                                     value={option.id}
-                                    data-selected={option.id === value || (value && value.includes(option.id))}
                                     className={clsx(
                                         overrides?.option,
                                         styles.option,

--- a/src/stories/select/Select.tsx
+++ b/src/stories/select/Select.tsx
@@ -6,7 +6,9 @@ import type {
     CSSProperties, ComponentPropsWithoutRef, ForwardedRef, ReactNode,
 } from 'react';
 import { forwardRef, useId } from 'react';
-import { Listbox, RadioGroup, Transition } from '@headlessui/react';
+import {
+    Listbox, ListboxButton, ListboxOptions, ListboxOption, RadioGroup, Radio, Transition,
+} from '@headlessui/react';
 import clsx from 'clsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
@@ -187,7 +189,7 @@ export const Select = forwardRef(function <T = Record<string, any>>({
                     onChange={onChange}
                     multiple={multiple}
                 >
-                    <Listbox.Button
+                    <ListboxButton
                         id={inputID}
                         {...overrides?.selectInput}
                         aria-disabled={disabled}
@@ -230,7 +232,7 @@ export const Select = forwardRef(function <T = Record<string, any>>({
                         ) : (
                             <FontAwesomeIcon className={clsx(inputStyles.enhancer, styles.chevron)} data-status={disabled ? 'disabled' : (status || 'default')} width="10px" icon={faChevronDown} />
                         )}
-                    </Listbox.Button>
+                    </ListboxButton>
                     <Transition
                         as="div"
                         className={dropdownStyles.transitionContainer}
@@ -241,7 +243,7 @@ export const Select = forwardRef(function <T = Record<string, any>>({
                         leaveFrom={dropdownStyles.leaveFrom}
                         leaveTo={dropdownStyles.leaveTo}
                     >
-                        <Listbox.Options
+                        <ListboxOptions
                             className={clsx(
                                 overrides?.optionsContainer,
                                 styles.options,
@@ -251,7 +253,7 @@ export const Select = forwardRef(function <T = Record<string, any>>({
                             } as CSSProperties}
                         >
                             {(options || []).map((option) => (
-                                <Listbox.Option
+                                <ListboxOption
                                     key={option.id}
                                     value={option.id}
                                     data-selected={option.id === value || (value && value.includes(option.id))}
@@ -270,16 +272,16 @@ export const Select = forwardRef(function <T = Record<string, any>>({
                                     {(option.id === value || (value && value.includes(option.id))) && (
                                         <Icon icon={Check} size={12} />
                                     )}
-                                </Listbox.Option>
+                                </ListboxOption>
                             ))}
-                        </Listbox.Options>
+                        </ListboxOptions>
                     </Transition>
                 </Listbox>
             )}
             {kind === 'radio' && (
                 <RadioGroup ref={ref} as="div" className={styles.radioContainer} value={value} onChange={onChange}>
                     {options.map((option) => (
-                        <RadioGroup.Option
+                        <Radio
                             as="div"
                             className={clsx(
                                 styles.radioOption,
@@ -293,14 +295,14 @@ export const Select = forwardRef(function <T = Record<string, any>>({
                             <TextWhenString kind="paragraphXSmall">
                                 {option.node}
                             </TextWhenString>
-                        </RadioGroup.Option>
+                        </Radio>
                     ))}
                 </RadioGroup>
             )}
             {kind === 'card' && (
                 <RadioGroup ref={ref} as="div" className={styles.cardContainer} value={value} onChange={onChange}>
                     {options.map((option) => (
-                        <RadioGroup.Option
+                        <Radio
                             as="div"
                             className={clsx(
                                 styles.cardOption,
@@ -315,14 +317,14 @@ export const Select = forwardRef(function <T = Record<string, any>>({
                                     {option.node}
                                 </TextWhenString>
                             </div>
-                        </RadioGroup.Option>
+                        </Radio>
                     ))}
                 </RadioGroup>
             )}
             {kind === 'segmented' && (
                 <RadioGroup ref={ref} as="div" className={styles.segmentedContainer} value={value || options[0].id} onChange={onChange}>
                     {options.map((option) => (
-                        <RadioGroup.Option
+                        <Radio
                             as="div"
                             className={clsx(
                                 styles.segmentedOption,
@@ -346,7 +348,7 @@ export const Select = forwardRef(function <T = Record<string, any>>({
                             <TextWhenString kind="paragraphXSmall" weight="medium" className={styles.segmentedText}>
                                 {option.node}
                             </TextWhenString>
-                        </RadioGroup.Option>
+                        </Radio>
                     ))}
                 </RadioGroup>
             )}

--- a/src/stories/tabs/Tabs.tsx
+++ b/src/stories/tabs/Tabs.tsx
@@ -5,7 +5,9 @@ import type {
 } from 'react';
 import { useId, useState } from 'react';
 import type { TabGroupProps, TabPanelProps, TabProps } from '@headlessui/react';
-import { Tab } from '@headlessui/react';
+import {
+    Tab, TabGroup, TabList, TabPanels, TabPanel,
+} from '@headlessui/react';
 import clsx from 'clsx';
 import type { CSSLength } from '@ssh/csstypes';
 import { motion } from 'framer-motion';
@@ -99,7 +101,7 @@ export const Tabs: FC<TabsProps> = ({
     const [selectedIndex, setSelectedIndex] = useState(defaultIndex);
 
     return (
-        <Tab.Group
+        <TabGroup
             as="div"
             selectedIndex={index ?? selectedIndex}
             onChange={(i) => {
@@ -121,7 +123,7 @@ export const Tabs: FC<TabsProps> = ({
                         <div className={styles.glassBlend} />
                     </div>
                 )}
-                <Tab.List
+                <TabList
                     {...overrides?.tabList}
                     style={{
                         '--tab-width': tabWidth,
@@ -160,19 +162,19 @@ export const Tabs: FC<TabsProps> = ({
                     ))}
 
                     {/* <div key={`${id}-tab-active-border`} className={styles.activeTabBorder} /> */}
-                </Tab.List>
+                </TabList>
                 <div
                     {...overrides?.tabListBorder}
                     className={clsx(styles.tabListBorder, styles[barStyle], overrides?.tabListBorder?.className)}
                 />
             </div>
 
-            <Tab.Panels
+            <TabPanels
                 {...overrides?.panelContainer}
                 className={clsx(styles.tabPanels, styles[backgroundStyle], overrides?.panelContainer?.className)}
             >
                 {tabs.map(({ title, content }) => (
-                    <Tab.Panel
+                    <TabPanel
                         key={`${id}-tab-${title}-content`}
                         {...overrides?.panel}
                         className={clsx(
@@ -184,9 +186,9 @@ export const Tabs: FC<TabsProps> = ({
                         )}
                     >
                         {content}
-                    </Tab.Panel>
+                    </TabPanel>
                 ))}
-            </Tab.Panels>
-        </Tab.Group>
+            </TabPanels>
+        </TabGroup>
     );
 };


### PR DESCRIPTION
* Upgraded to headlessui v2, affecting the Combobox, Dialog, Drawer, Menu, Select, and Tabs components
* Combobox: Options dropdown now opens on focus, added `hideOptionsInitially` prop disable behavior
* Menu: Exports changed from dot notation to explicit named exports
* Select: multiselect listbox stays open so you can click multiple options, instead of closing after each one
* Checkbox: added new `switch` kind, plus `hideLabel` prop
* Misc: Select listbox, Combobox, and Menu now render as modal by default because of headless v2, meaning page is scroll locked