### PR TITLE
fix: checkbox panel remove hover

### DIFF
--- a/.changeset/calm-rings-knock.md
+++ b/.changeset/calm-rings-knock.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+Checkbox: removed background hover from `panel` variant

--- a/src/stories/checkbox/Checkbox.module.scss
+++ b/src/stories/checkbox/Checkbox.module.scss
@@ -115,9 +115,9 @@
             color: var(--pte-new-colors-contentDisabled);
         }
 
-        &:hover {
-            background-color: var(--pte-new-colors-overlaySubtle);
-        }
+        //&:hover {
+        //    background-color: var(--pte-new-colors-overlaySubtle);
+        //}
 
         .box {
             width: 13px;


### PR DESCRIPTION
* Checkbox: Removed bg hover state for `panel` kind.