### PR TITLE
fix(drawer): animate on first open when mounted already-open

### DIFF
--- a/.changeset/drawer-appear-first-mount.md
+++ b/.changeset/drawer-appear-first-mount.md
@@ -1,0 +1,5 @@
+---
+"paris": patch
+---
+
+Drawer: animate on first open when mounted already-open. Added `appear` to the Drawer's headlessui `Transition` so a conditionally-rendered Drawer whose first render is `show={true}` animates in instead of snapping open. Always-mounted Drawers are unaffected (they mount with `show={false}`, for which `appear` is a no-op).

--- a/src/stories/drawer/Drawer.tsx
+++ b/src/stories/drawer/Drawer.tsx
@@ -195,7 +195,13 @@ export const Drawer = <T extends string[] | readonly string[] = string[]>(props:
     }, [onAfterClose]);
 
     return (
-        <Transition show={isOpen} afterLeave={handleAfterLeave}>
+        // `appear` runs the enter transition on the very first mount. Without it,
+        // a Drawer that is conditionally rendered and mounts already-open (i.e. its
+        // first render has `show={true}`) snaps straight to the open state instead of
+        // animating in. Always-mounted Drawers mount with `show={false}`, so `appear`
+        // is a no-op for them — it only adds the (desired) enter animation for the
+        // mount-open case.
+        <Transition show={isOpen} appear afterLeave={handleAfterLeave}>
             <Dialog
                 as="div"
                 className={clsx(styles.root, props.overrides?.dialog?.className)}


### PR DESCRIPTION
## What

Adds `appear` to the Drawer's headlessui `<Transition>`.

## Why

A conditionally-rendered Drawer whose **first render is `show={true}`** (i.e. it mounts already-open) snapped straight to the open state instead of running the slide/fade enter animation — headlessui suppresses the enter transition on initial mount unless `appear` is set.

This surfaced in Midnights as "the first transaction clicked on /transactions always flashes in instead of animating": the detail drawer there is conditionally mounted, so its very first open coincides with mount.

## Blast radius

Narrow and additive. `appear` only affects Drawers that **mount already-open**:
- Conditionally-mounted Drawers (mount with `show={true}`) → now animate in ✅
- Always-mounted Drawers (mount with `show={false}`, toggle `isOpen` later) → **unaffected**; `appear` is a no-op on a mount where `show` is false.

So it cannot regress the common always-mounted pattern.

## Notes

- Includes a patch changeset.
- Needed by Midnights to fix the /transactions first-open flash once published + bumped.