### PR TITLE
misc: Paris form-input fixes, props, forward refs, generic typing & focus/error support

### DIFF
--- a/.changeset/combobox-forward-ref.md
+++ b/.changeset/combobox-forward-ref.md
@@ -1,0 +1,11 @@
+---
+"paris": patch
+---
+
+Form inputs now forward a `ref` to their focusable element, so form libraries (e.g. react-hook-form's `field.ref` / `setFocus`) can focus a field when it's invalid:
+
+- `Combobox` → its `<input>` (also fixes `Input`'s type annotation, which was `FC` and hid the forwarded `ref`).
+- `Checkbox` → the underlying checkbox / switch control.
+- `CodeInput` → the first digit cell.
+- `AccordionSelect` → its header trigger.
+- `Select` (listbox) → its `ListboxButton` (the focusable trigger) instead of the wrapping `Listbox` div.

--- a/.changeset/form-field-focus-error.md
+++ b/.changeset/form-field-focus-error.md
@@ -1,0 +1,11 @@
+---
+"paris": minor
+---
+
+Round out programmatic focus (`setFocus`) and per-field error state across form components, building on the new `forwardRef` support:
+
+- `Checkbox` and `AccordionSelect` gain a `status?: 'default' | 'error'` prop that renders an invalid treatment (e.g. for a required field), matching `Input`/`Select`.
+- `Select`'s `radio`/`card`/`segmented` kinds are now focusable (the group receives `tabIndex={-1}`), so `setFocus` works for them — previously only the `listbox` kind was.
+- `Combobox` keeps a focusable target for its forwarded `ref` even when the selected option's `node` is a non-string element (previously the ref went `null` and `setFocus` no-oped).
+- `MarkdownEditor` exposes an imperative handle via `ref` (`MarkdownEditorHandle` with `focus()`), so consumers can focus the editor without reaching into Tiptap internals.
+- `Drawer` adds an `onPageEntered(pageID)` callback that fires once a paginated page's content has mounted and its enter transition completed, so consumers can focus a field on a newly-navigated page deterministically instead of polling animation frames.

--- a/.changeset/generic-option-components.md
+++ b/.changeset/generic-option-components.md
@@ -1,0 +1,21 @@
+---
+"paris": minor
+---
+
+Option-based components are now genuinely generic over their `metadata` type, and their callbacks are typed accordingly.
+
+**Breaking — `Select` `onChange`:** it now receives the full selected `Option<T>` (single) or `Option<T>[]` (multiple) — including typed `metadata` — instead of the option `id` string(s). `value`/`defaultValue` are unchanged (still id-based). Migrate by reading `option.id`:
+
+```tsx
+// before
+<Select options={opts} onChange={(id) => setValue(id)} />
+// after
+<Select options={opts} onChange={(option) => setValue(option?.id ?? null)} />
+```
+
+Also in this release (non-breaking):
+
+- `Select` and `AccordionSelect` now preserve their generic type parameter, so `<Select<MyMeta> />` / `<AccordionSelect<MyMeta> />` correctly type `options`, `onChange`, and the render callbacks. (Previously the parameter was silently erased by `forwardRef`, and `Select`'s `options` never received the type at all.)
+- `Tabs` is now generic over an optional per-tab `id`; `onTabChange(index, id)` receives that typed id as a second argument.
+- `Option`/`AccordionSelectOption` metadata now defaults to `Record<string, unknown>` (was `Record<string, any>`).
+- `Menu` dropdowns no longer paint a stray drop shadow when rendered with no items (matches the same fix on `Select`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@ src/stories/<componentname>/
 - **Select** - Dropdown/listbox/radio/segmented selection
 - **Checkbox** - Checkbox with switch variant
 - **Combobox** - Autocomplete input
+- **AccordionSelect** - Card header that expands to reveal selectable options
+
+**Generic option typing:** `Select`, `Combobox`, and `AccordionSelect` are generic over their option `metadata` type (`<Select<MyMeta> />`), and their `onChange` returns the full selected `Option<T>` (or `Option<T>[]` for multi-select), including typed `metadata`. `Tabs` is generic over an optional per-tab `id`, surfaced as the second arg of `onTabChange(index, id)`.
 
 ### Navigation & Actions
 - **Button** - Primary action trigger

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ src/stories/<componentname>/
 
 **Generic option typing:** `Select`, `Combobox`, and `AccordionSelect` are generic over their option `metadata` type (`<Select<MyMeta> />`), and their `onChange` returns the full selected `Option<T>` (or `Option<T>[]` for multi-select), including typed `metadata`. `Tabs` is generic over an optional per-tab `id`, surfaced as the second arg of `onTabChange(index, id)`.
 
+**Programmatic focus & error state:** form components forward a `ref` to a focusable element so `react-hook-form`'s `setFocus` works — including `Select`'s `radio`/`card`/`segmented` kinds and `Combobox` with a non-string selected node. `MarkdownEditor` exposes an imperative `ref` handle (`{ focus() }`) instead of a DOM ref. `Checkbox` and `AccordionSelect` support `status="error"` (like `Input`/`Select`) for invalid state. For paginated `Drawer`s, `onPageEntered(pageID)` fires once a page has mounted so consumers can focus a field on the new page deterministically.
+
 ### Navigation & Actions
 - **Button** - Primary action trigger
 - **StyledLink** - Styled anchor element

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ The theme engine (`pte`) generates CSS variables from TypeScript theme definitio
 
 **Generic Option Components**: `Select`, `Combobox`, and `AccordionSelect` are generic over their option `metadata` type (`Option<T>`), and their `onChange` returns the full selected option(s) with typed `metadata` (not just the id). Because `forwardRef` erases generics, these components cast their `forwardRef` export back to a generic function type so `<Select<MyMeta> />` keeps working — follow that pattern when adding a generic + ref-forwarding component. `Tabs` is generic over an optional per-tab `id` passed to `onTabChange`.
 
+**Form Focus & Error State**: form inputs forward a `ref` to a focusable element for `react-hook-form` `setFocus` (the ref target must stay mounted and focusable — e.g. `Select`'s radio/card/segmented groups carry `tabIndex={-1}`, and `Combobox` falls back to its container when the input unmounts). Components without a DOM input (`MarkdownEditor`) expose an imperative `{ focus() }` handle via `useImperativeHandle` instead. Field-like components take `status?: 'default' | 'error'` and render error state via a `data-status="error"` attribute styled in SCSS.
+
 ### Z-Index Layering
 
 Global z-index values use semantic layer tokens defined in `Theme.new.layers`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ The theme engine (`pte`) generates CSS variables from TypeScript theme definitio
 
 **Field Wrapper**: Form inputs (Input, Select, Combobox, TextArea) use the `Field` component for consistent label/description handling.
 
+**Generic Option Components**: `Select`, `Combobox`, and `AccordionSelect` are generic over their option `metadata` type (`Option<T>`), and their `onChange` returns the full selected option(s) with typed `metadata` (not just the id). Because `forwardRef` erases generics, these components cast their `forwardRef` export back to a generic function type so `<Select<MyMeta> />` keeps working — follow that pattern when adding a generic + ref-forwarding component. `Tabs` is generic over an optional per-tab `id` passed to `onTabChange`.
+
 ### Z-Index Layering
 
 Global z-index values use semantic layer tokens defined in `Theme.new.layers`:

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -158,10 +158,13 @@ disabled?: boolean
 
 ## Select Props
 
+Generic over the option `metadata` type: `<Select<MyMeta> />` types `options` and `onChange`.
+
 ```tsx
 options: { id: string, node: ReactNode, disabled?: boolean, metadata?: T }[]
-value?: string | string[]
-onChange?: (value) => void
+value?: string | string[]                          // id(s); unchanged
+onChange?: (option: Option<T> | null) => void      // single: the selected Option (with metadata)
+onChange?: (options: Option<T>[] | null) => void   // multiple: the selected Options
 kind?: 'listbox' | 'radio' | 'card' | 'segmented'  // default: 'listbox'
 multiple?: boolean
 label: ReactNode

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -65,6 +65,7 @@ import { Input } from 'paris/input';
 - Select - Dropdown/listbox/radio/segmented selection
 - Checkbox - Checkbox with switch variant
 - Combobox - Autocomplete input
+- AccordionSelect - Card header that expands to reveal selectable options
 - Field - Form field wrapper with label
 
 ### Navigation & Actions
@@ -140,6 +141,7 @@ disabled?: boolean
 startEnhancer?: ReactNode | (({ size }) => ReactNode)
 endEnhancer?: ReactNode | (({ size }) => ReactNode)
 href?: string  // Renders as anchor
+displayNotificationDot?: boolean  // Shows a notification dot in the top-right corner
 ```
 
 ## Input Props

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -282,6 +282,7 @@ placeholder?: string
 size?: MarkdownSize                              // Body text size
 editable?: boolean                               // default: true
 status?: 'default' | 'error' | 'success'
+ref?: Ref<MarkdownEditorHandle>                  // imperative { focus() } handle
 ```
 
 ## Key Dependencies

--- a/src/stories/accordionselect/AccordionSelect.module.scss
+++ b/src/stories/accordionselect/AccordionSelect.module.scss
@@ -9,6 +9,10 @@
     &.open {
         border-color: var(--pte-new-colors-borderUltrastrong);
     }
+
+    &[data-status="error"] {
+        border-color: var(--pte-new-colors-inputBorderNegative);
+    }
 }
 
 .header {

--- a/src/stories/accordionselect/AccordionSelect.tsx
+++ b/src/stories/accordionselect/AccordionSelect.tsx
@@ -46,6 +46,12 @@ export type AccordionSelectProps<T extends Record<string, unknown> = Record<stri
      */
     onChange?: (option: AccordionSelectOption<T>) => void;
     /**
+     * The validation status of the field. `error` renders an invalid treatment. Follows the
+     * `Input`/`Select` pattern.
+     * @default 'default'
+     */
+    status?: 'default' | 'error';
+    /**
      * Custom content to render as the header when an option is selected.
      * Receives the selected option. If not provided, the option's `node` is used.
      */
@@ -119,6 +125,7 @@ const AccordionSelectInner = <T extends Record<string, unknown> = Record<string,
         renderSelected,
         renderOption,
         placeholder = 'Select an option',
+        status = 'default',
         isOpen: controlledOpen,
         onOpenChange,
         closeOnSelect = true,
@@ -171,6 +178,7 @@ const AccordionSelectInner = <T extends Record<string, unknown> = Record<string,
         <div
             ref={rootRef}
             {...overrides?.root}
+            data-status={status}
             className={clsx(styles.root, open && styles.open, overrides?.root?.className)}
         >
             <div

--- a/src/stories/accordionselect/AccordionSelect.tsx
+++ b/src/stories/accordionselect/AccordionSelect.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { clsx } from 'clsx';
-import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ForwardedRef, ReactNode, RefAttributes } from 'react';
 import { forwardRef, useEffect, useRef } from 'react';
 import { useControllableState } from '../../helpers/useControllableState';
 import { Check, ChevronRight, Icon } from '../icon';
 import { TextWhenString } from '../utility';
 import styles from './AccordionSelect.module.scss';
 
-export type AccordionSelectOption<T = Record<string, unknown>> = {
+export type AccordionSelectOption<T extends Record<string, unknown> = Record<string, unknown>> = {
     /**
      * A unique identifier for the option.
      */
@@ -28,7 +28,7 @@ export type AccordionSelectOption<T = Record<string, unknown>> = {
     metadata?: T;
 };
 
-export type AccordionSelectProps<T = Record<string, unknown>> = {
+export type AccordionSelectProps<T extends Record<string, unknown> = Record<string, unknown>> = {
     /**
      * The list of selectable options.
      */
@@ -110,148 +110,157 @@ export type AccordionSelectProps<T = Record<string, unknown>> = {
  * ```
  * @constructor
  */
-export const AccordionSelect = forwardRef<HTMLDivElement, AccordionSelectProps>(
-    (
-        {
-            options,
-            value,
-            defaultValue,
-            onChange,
-            renderSelected,
-            renderOption,
-            placeholder = 'Select an option',
-            isOpen: controlledOpen,
-            onOpenChange,
-            closeOnSelect = true,
-            closeOnClickOutside = true,
-            action,
-            label,
-            overrides,
+const AccordionSelectInner = <T extends Record<string, unknown> = Record<string, unknown>>(
+    {
+        options,
+        value,
+        defaultValue,
+        onChange,
+        renderSelected,
+        renderOption,
+        placeholder = 'Select an option',
+        isOpen: controlledOpen,
+        onOpenChange,
+        closeOnSelect = true,
+        closeOnClickOutside = true,
+        action,
+        label,
+        overrides,
+    }: AccordionSelectProps<T>,
+    ref: ForwardedRef<HTMLDivElement>,
+): ReactNode => {
+    const [open, setOpen] = useControllableState({
+        value: controlledOpen,
+        defaultValue: false,
+        onChange: onOpenChange,
+    });
+    const rootRef = useRef<HTMLDivElement>(null);
+
+    const [resolvedValue, setResolvedValue] = useControllableState<string | null>({
+        value,
+        defaultValue,
+        onChange: (id) => {
+            const option = options.find((o) => o.id === id);
+            if (option) onChange?.(option);
         },
-        ref,
-    ) => {
-        const [open, setOpen] = useControllableState({
-            value: controlledOpen,
-            defaultValue: false,
-            onChange: onOpenChange,
-        });
-        const rootRef = useRef<HTMLDivElement>(null);
+    });
 
-        const [resolvedValue, setResolvedValue] = useControllableState<string | null>({
-            value,
-            defaultValue,
-            onChange: (id) => {
-                const option = options.find((o) => o.id === id);
-                if (option) onChange?.(option);
-            },
-        });
+    const selectedOption = options.find((o) => o.id === resolvedValue);
 
-        const selectedOption = options.find((o) => o.id === resolvedValue);
-
-        useEffect(() => {
-            if (!closeOnClickOutside || !open) {
-                return () => {};
-            }
-
-            const handleClickOutside = (e: MouseEvent) => {
-                if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-                    setOpen(false);
-                }
-            };
-
-            document.addEventListener('mousedown', handleClickOutside);
-            return () => document.removeEventListener('mousedown', handleClickOutside);
-        }, [closeOnClickOutside, open, setOpen]);
-
-        let headerContent: ReactNode = placeholder;
-        if (selectedOption) {
-            headerContent = renderSelected ? renderSelected(selectedOption) : selectedOption.node;
+    useEffect(() => {
+        if (!closeOnClickOutside || !open) {
+            return () => {};
         }
 
-        return (
-            <div
-                ref={rootRef}
-                {...overrides?.root}
-                className={clsx(styles.root, open && styles.open, overrides?.root?.className)}
-            >
-                <div
-                    ref={ref}
-                    {...overrides?.header}
-                    className={clsx(styles.header, open && styles.open, overrides?.header?.className)}
-                    onClick={() => setOpen(!open)}
-                    onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            setOpen(!open);
-                        }
-                    }}
-                    role="button"
-                    tabIndex={0}
-                >
-                    <div className={styles.headerContent}>
-                        <TextWhenString kind="paragraphSmall" weight="medium">
-                            {headerContent}
-                        </TextWhenString>
-                    </div>
-                    <div className={styles.headerEnd}>
-                        {label}
-                        <Icon icon={ChevronRight} size={16} className={clsx(styles.chevron, open && styles.open)} />
-                    </div>
-                </div>
+        const handleClickOutside = (e: MouseEvent) => {
+            if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
 
-                {/*
-                 * Collapse animation uses the CSS grid-rows trick (`1fr` → `0fr`) instead
-                 * of animating `height: auto`. JS-driven height-auto animations (e.g.
-                 * framer-motion) flash an intermediate layout state on open/close that
-                 * causes scrollable ancestors to clamp `scrollTop` to 0 in the first
-                 * paint frame — visible as an instant scroll snap before the animation
-                 * starts. The grid-rows approach keeps the layout stable across the
-                 * entire transition.
-                 */}
-                <div
-                    {...overrides?.dropdown}
-                    aria-hidden={!open}
-                    className={clsx(styles.dropdown, open && styles.open, overrides?.dropdown?.className)}
-                >
-                    <div
-                        {...overrides?.dropdownContent}
-                        className={clsx(styles.dropdownContent, overrides?.dropdownContent?.className)}
-                    >
-                        {options.map((option) => {
-                            const isOptionSelected = option.id === resolvedValue;
-                            return (
-                                <button
-                                    key={option.id}
-                                    type="button"
-                                    disabled={option.disabled || !open}
-                                    tabIndex={open ? undefined : -1}
-                                    data-selected={isOptionSelected}
-                                    {...overrides?.option}
-                                    className={clsx(styles.option, overrides?.option?.className)}
-                                    onClick={() => {
-                                        setResolvedValue(option.id);
-                                        if (closeOnSelect) setOpen(false);
-                                    }}
-                                >
-                                    <div className={styles.optionContent}>
-                                        {renderOption ? (
-                                            renderOption(option, isOptionSelected)
-                                        ) : (
-                                            <TextWhenString kind="paragraphXSmall" weight="medium">
-                                                {option.node}
-                                            </TextWhenString>
-                                        )}
-                                    </div>
-                                    {isOptionSelected && <Icon icon={Check} size={13} className={styles.check} />}
-                                </button>
-                            );
-                        })}
-                        {action}
-                    </div>
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [closeOnClickOutside, open, setOpen]);
+
+    let headerContent: ReactNode = placeholder;
+    if (selectedOption) {
+        headerContent = renderSelected ? renderSelected(selectedOption) : selectedOption.node;
+    }
+
+    return (
+        <div
+            ref={rootRef}
+            {...overrides?.root}
+            className={clsx(styles.root, open && styles.open, overrides?.root?.className)}
+        >
+            <div
+                ref={ref}
+                {...overrides?.header}
+                className={clsx(styles.header, open && styles.open, overrides?.header?.className)}
+                onClick={() => setOpen(!open)}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        setOpen(!open);
+                    }
+                }}
+                role="button"
+                tabIndex={0}
+            >
+                <div className={styles.headerContent}>
+                    <TextWhenString kind="paragraphSmall" weight="medium">
+                        {headerContent}
+                    </TextWhenString>
+                </div>
+                <div className={styles.headerEnd}>
+                    {label}
+                    <Icon icon={ChevronRight} size={16} className={clsx(styles.chevron, open && styles.open)} />
                 </div>
             </div>
-        );
-    },
-);
+
+            {/*
+             * Collapse animation uses the CSS grid-rows trick (`1fr` → `0fr`) instead
+             * of animating `height: auto`. JS-driven height-auto animations (e.g.
+             * framer-motion) flash an intermediate layout state on open/close that
+             * causes scrollable ancestors to clamp `scrollTop` to 0 in the first
+             * paint frame — visible as an instant scroll snap before the animation
+             * starts. The grid-rows approach keeps the layout stable across the
+             * entire transition.
+             */}
+            <div
+                {...overrides?.dropdown}
+                aria-hidden={!open}
+                className={clsx(styles.dropdown, open && styles.open, overrides?.dropdown?.className)}
+            >
+                <div
+                    {...overrides?.dropdownContent}
+                    className={clsx(styles.dropdownContent, overrides?.dropdownContent?.className)}
+                >
+                    {options.map((option) => {
+                        const isOptionSelected = option.id === resolvedValue;
+                        return (
+                            <button
+                                key={option.id}
+                                type="button"
+                                disabled={option.disabled || !open}
+                                tabIndex={open ? undefined : -1}
+                                data-selected={isOptionSelected}
+                                {...overrides?.option}
+                                className={clsx(styles.option, overrides?.option?.className)}
+                                onClick={() => {
+                                    setResolvedValue(option.id);
+                                    if (closeOnSelect) setOpen(false);
+                                }}
+                            >
+                                <div className={styles.optionContent}>
+                                    {renderOption ? (
+                                        renderOption(option, isOptionSelected)
+                                    ) : (
+                                        <TextWhenString kind="paragraphXSmall" weight="medium">
+                                            {option.node}
+                                        </TextWhenString>
+                                    )}
+                                </div>
+                                {isOptionSelected && <Icon icon={Check} size={13} className={styles.check} />}
+                            </button>
+                        );
+                    })}
+                    {action}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+/**
+ * `forwardRef` erases the generic type parameter, so cast the result back to a generic function
+ * type. This keeps `<AccordionSelect<MyMeta> />` working (typing `onChange`/`renderOption` with
+ * `AccordionSelectOption<MyMeta>`) while still forwarding the ref to the header element.
+ */
+export const AccordionSelect = forwardRef(AccordionSelectInner) as unknown as (<
+    T extends Record<string, unknown> = Record<string, unknown>,
+>(
+    props: AccordionSelectProps<T> & RefAttributes<HTMLDivElement>,
+) => ReactNode) & { displayName?: string };
 
 AccordionSelect.displayName = 'AccordionSelect';

--- a/src/stories/accordionselect/AccordionSelect.tsx
+++ b/src/stories/accordionselect/AccordionSelect.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { clsx } from 'clsx';
-import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
-import { useEffect, useRef } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { forwardRef, useEffect, useRef } from 'react';
 import { useControllableState } from '../../helpers/useControllableState';
 import { Check, ChevronRight, Icon } from '../icon';
 import { TextWhenString } from '../utility';
@@ -110,140 +110,148 @@ export type AccordionSelectProps<T = Record<string, unknown>> = {
  * ```
  * @constructor
  */
-export const AccordionSelect: FC<AccordionSelectProps> = ({
-    options,
-    value,
-    defaultValue,
-    onChange,
-    renderSelected,
-    renderOption,
-    placeholder = 'Select an option',
-    isOpen: controlledOpen,
-    onOpenChange,
-    closeOnSelect = true,
-    closeOnClickOutside = true,
-    action,
-    label,
-    overrides,
-}) => {
-    const [open, setOpen] = useControllableState({
-        value: controlledOpen,
-        defaultValue: false,
-        onChange: onOpenChange,
-    });
-    const rootRef = useRef<HTMLDivElement>(null);
-
-    const [resolvedValue, setResolvedValue] = useControllableState<string | null>({
-        value,
-        defaultValue,
-        onChange: (id) => {
-            const option = options.find((o) => o.id === id);
-            if (option) onChange?.(option);
+export const AccordionSelect = forwardRef<HTMLDivElement, AccordionSelectProps>(
+    (
+        {
+            options,
+            value,
+            defaultValue,
+            onChange,
+            renderSelected,
+            renderOption,
+            placeholder = 'Select an option',
+            isOpen: controlledOpen,
+            onOpenChange,
+            closeOnSelect = true,
+            closeOnClickOutside = true,
+            action,
+            label,
+            overrides,
         },
-    });
+        ref,
+    ) => {
+        const [open, setOpen] = useControllableState({
+            value: controlledOpen,
+            defaultValue: false,
+            onChange: onOpenChange,
+        });
+        const rootRef = useRef<HTMLDivElement>(null);
 
-    const selectedOption = options.find((o) => o.id === resolvedValue);
+        const [resolvedValue, setResolvedValue] = useControllableState<string | null>({
+            value,
+            defaultValue,
+            onChange: (id) => {
+                const option = options.find((o) => o.id === id);
+                if (option) onChange?.(option);
+            },
+        });
 
-    useEffect(() => {
-        if (!closeOnClickOutside || !open) {
-            return () => {};
+        const selectedOption = options.find((o) => o.id === resolvedValue);
+
+        useEffect(() => {
+            if (!closeOnClickOutside || !open) {
+                return () => {};
+            }
+
+            const handleClickOutside = (e: MouseEvent) => {
+                if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+                    setOpen(false);
+                }
+            };
+
+            document.addEventListener('mousedown', handleClickOutside);
+            return () => document.removeEventListener('mousedown', handleClickOutside);
+        }, [closeOnClickOutside, open, setOpen]);
+
+        let headerContent: ReactNode = placeholder;
+        if (selectedOption) {
+            headerContent = renderSelected ? renderSelected(selectedOption) : selectedOption.node;
         }
 
-        const handleClickOutside = (e: MouseEvent) => {
-            if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-                setOpen(false);
-            }
-        };
-
-        document.addEventListener('mousedown', handleClickOutside);
-        return () => document.removeEventListener('mousedown', handleClickOutside);
-    }, [closeOnClickOutside, open, setOpen]);
-
-    let headerContent: ReactNode = placeholder;
-    if (selectedOption) {
-        headerContent = renderSelected ? renderSelected(selectedOption) : selectedOption.node;
-    }
-
-    return (
-        <div
-            ref={rootRef}
-            {...overrides?.root}
-            className={clsx(styles.root, open && styles.open, overrides?.root?.className)}
-        >
+        return (
             <div
-                {...overrides?.header}
-                className={clsx(styles.header, open && styles.open, overrides?.header?.className)}
-                onClick={() => setOpen(!open)}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        setOpen(!open);
-                    }
-                }}
-                role="button"
-                tabIndex={0}
-            >
-                <div className={styles.headerContent}>
-                    <TextWhenString kind="paragraphSmall" weight="medium">
-                        {headerContent}
-                    </TextWhenString>
-                </div>
-                <div className={styles.headerEnd}>
-                    {label}
-                    <Icon icon={ChevronRight} size={16} className={clsx(styles.chevron, open && styles.open)} />
-                </div>
-            </div>
-
-            {/*
-             * Collapse animation uses the CSS grid-rows trick (`1fr` → `0fr`) instead
-             * of animating `height: auto`. JS-driven height-auto animations (e.g.
-             * framer-motion) flash an intermediate layout state on open/close that
-             * causes scrollable ancestors to clamp `scrollTop` to 0 in the first
-             * paint frame — visible as an instant scroll snap before the animation
-             * starts. The grid-rows approach keeps the layout stable across the
-             * entire transition.
-             */}
-            <div
-                {...overrides?.dropdown}
-                aria-hidden={!open}
-                className={clsx(styles.dropdown, open && styles.open, overrides?.dropdown?.className)}
+                ref={rootRef}
+                {...overrides?.root}
+                className={clsx(styles.root, open && styles.open, overrides?.root?.className)}
             >
                 <div
-                    {...overrides?.dropdownContent}
-                    className={clsx(styles.dropdownContent, overrides?.dropdownContent?.className)}
+                    ref={ref}
+                    {...overrides?.header}
+                    className={clsx(styles.header, open && styles.open, overrides?.header?.className)}
+                    onClick={() => setOpen(!open)}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            setOpen(!open);
+                        }
+                    }}
+                    role="button"
+                    tabIndex={0}
                 >
-                    {options.map((option) => {
-                        const isOptionSelected = option.id === resolvedValue;
-                        return (
-                            <button
-                                key={option.id}
-                                type="button"
-                                disabled={option.disabled || !open}
-                                tabIndex={open ? undefined : -1}
-                                data-selected={isOptionSelected}
-                                {...overrides?.option}
-                                className={clsx(styles.option, overrides?.option?.className)}
-                                onClick={() => {
-                                    setResolvedValue(option.id);
-                                    if (closeOnSelect) setOpen(false);
-                                }}
-                            >
-                                <div className={styles.optionContent}>
-                                    {renderOption ? (
-                                        renderOption(option, isOptionSelected)
-                                    ) : (
-                                        <TextWhenString kind="paragraphXSmall" weight="medium">
-                                            {option.node}
-                                        </TextWhenString>
-                                    )}
-                                </div>
-                                {isOptionSelected && <Icon icon={Check} size={13} className={styles.check} />}
-                            </button>
-                        );
-                    })}
-                    {action}
+                    <div className={styles.headerContent}>
+                        <TextWhenString kind="paragraphSmall" weight="medium">
+                            {headerContent}
+                        </TextWhenString>
+                    </div>
+                    <div className={styles.headerEnd}>
+                        {label}
+                        <Icon icon={ChevronRight} size={16} className={clsx(styles.chevron, open && styles.open)} />
+                    </div>
+                </div>
+
+                {/*
+                 * Collapse animation uses the CSS grid-rows trick (`1fr` → `0fr`) instead
+                 * of animating `height: auto`. JS-driven height-auto animations (e.g.
+                 * framer-motion) flash an intermediate layout state on open/close that
+                 * causes scrollable ancestors to clamp `scrollTop` to 0 in the first
+                 * paint frame — visible as an instant scroll snap before the animation
+                 * starts. The grid-rows approach keeps the layout stable across the
+                 * entire transition.
+                 */}
+                <div
+                    {...overrides?.dropdown}
+                    aria-hidden={!open}
+                    className={clsx(styles.dropdown, open && styles.open, overrides?.dropdown?.className)}
+                >
+                    <div
+                        {...overrides?.dropdownContent}
+                        className={clsx(styles.dropdownContent, overrides?.dropdownContent?.className)}
+                    >
+                        {options.map((option) => {
+                            const isOptionSelected = option.id === resolvedValue;
+                            return (
+                                <button
+                                    key={option.id}
+                                    type="button"
+                                    disabled={option.disabled || !open}
+                                    tabIndex={open ? undefined : -1}
+                                    data-selected={isOptionSelected}
+                                    {...overrides?.option}
+                                    className={clsx(styles.option, overrides?.option?.className)}
+                                    onClick={() => {
+                                        setResolvedValue(option.id);
+                                        if (closeOnSelect) setOpen(false);
+                                    }}
+                                >
+                                    <div className={styles.optionContent}>
+                                        {renderOption ? (
+                                            renderOption(option, isOptionSelected)
+                                        ) : (
+                                            <TextWhenString kind="paragraphXSmall" weight="medium">
+                                                {option.node}
+                                            </TextWhenString>
+                                        )}
+                                    </div>
+                                    {isOptionSelected && <Icon icon={Check} size={13} className={styles.check} />}
+                                </button>
+                            );
+                        })}
+                        {action}
+                    </div>
                 </div>
             </div>
-        </div>
-    );
-};
+        );
+    },
+);
+
+AccordionSelect.displayName = 'AccordionSelect';

--- a/src/stories/button/Button.module.scss
+++ b/src/stories/button/Button.module.scss
@@ -84,6 +84,30 @@
     }
 }
 
+/*
+ * NOTIFICATION DOT
+ *
+ * A fill-less button (secondary/tertiary) leaves the notification dot floating, so when a dot is
+ * present we give the button the filled treatment. Declared after the KIND block so its equal
+ * specificity wins over the kind rules via source order.
+ */
+.hasNotificationDot {
+    color: var(--pte-new-colors-contentInversePrimary);
+    background-color: var(--pte-new-colors-buttonFill);
+    border-color: var(--pte-new-colors-buttonFill);
+
+    &:hover {
+        background-color: var(--pte-new-colors-buttonFillHover);
+        border-color: var(--pte-new-colors-buttonFillHover);
+    }
+
+    &[aria-disabled=true] {
+        color: var(--pte-new-colors-contentDisabled);
+        background-color: var(--pte-new-colors-buttonFillDisabled);
+        border-color: var(--pte-new-colors-buttonFillDisabled);
+    }
+}
+
 
 /*
  * SIZE

--- a/src/stories/button/Button.module.scss
+++ b/src/stories/button/Button.module.scss
@@ -86,25 +86,22 @@
 
 /*
  * NOTIFICATION DOT
- *
- * A fill-less button (secondary/tertiary) leaves the notification dot floating, so when a dot is
- * present we give the button the filled treatment. Declared after the KIND block so its equal
- * specificity wins over the kind rules via source order.
  */
-.hasNotificationDot {
-    color: var(--pte-new-colors-contentInversePrimary);
-    background-color: var(--pte-new-colors-buttonFill);
-    border-color: var(--pte-new-colors-buttonFill);
+.notificationDot {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
 
-    &:hover {
+.hasNotificationDot[aria-disabled=false] {
+    &.primary {
         background-color: var(--pte-new-colors-buttonFillHover);
         border-color: var(--pte-new-colors-buttonFillHover);
     }
 
-    &[aria-disabled=true] {
-        color: var(--pte-new-colors-contentDisabled);
-        background-color: var(--pte-new-colors-buttonFillDisabled);
-        border-color: var(--pte-new-colors-buttonFillDisabled);
+    &.secondary,
+    &.tertiary {
+        background-color: var(--pte-new-colors-overlayMedium);
     }
 }
 

--- a/src/stories/button/Button.stories.ts
+++ b/src/stories/button/Button.stories.ts
@@ -2,12 +2,23 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { createElement } from 'react';
-import { Button } from './Button';
+import { Button, CornerPresets } from './Button';
 
 const meta: Meta<typeof Button> = {
     title: 'Inputs/Button',
     component: Button,
     tags: ['autodocs'],
+    argTypes: {
+        // `corners` is a `CornerPreset | CSSLength` union that Storybook can't infer a control for,
+        // so define it manually as a select over the presets (it also accepts any CSSLength string).
+        corners: {
+            control: 'select',
+            options: [...CornerPresets],
+            description:
+                'Corner rounding for the `rectangle` and `square` shapes. A preset (`sharp`, `rounded`, `roundedXL`) or any valid CSSLength string.',
+            table: { defaultValue: { summary: 'rounded' } },
+        },
+    },
 };
 
 export default meta;

--- a/src/stories/button/Button.test.tsx
+++ b/src/stories/button/Button.test.tsx
@@ -189,13 +189,13 @@ describe('Button', () => {
     describe('notification dot', () => {
         it('renders notification dot when displayNotificationDot is true', () => {
             const { container } = render(<Button displayNotificationDot>Label</Button>);
-            const dotWrapper = container.querySelector('.absolute');
+            const dotWrapper = container.querySelector('.notificationDot');
             expect(dotWrapper).toBeInTheDocument();
         });
 
         it('does not render notification dot by default', () => {
             const { container } = render(<Button>Label</Button>);
-            const dotWrapper = container.querySelector('.absolute');
+            const dotWrapper = container.querySelector('.notificationDot');
             expect(dotWrapper).not.toBeInTheDocument();
         });
     });

--- a/src/stories/button/Button.tsx
+++ b/src/stories/button/Button.tsx
@@ -188,6 +188,7 @@ export const Button: FC<ButtonProps> = ({
                 styles[shape],
                 styles[size],
                 cornersIsPreset && styles[corners],
+                displayNotificationDot && styles.hasNotificationDot,
                 props?.className,
             )}
             aria-disabled={disabled ?? false}

--- a/src/stories/button/Button.tsx
+++ b/src/stories/button/Button.tsx
@@ -218,7 +218,7 @@ export const Button: FC<ButtonProps> = ({
             )}
             {!!(endEnhancer && !loading) && <MemoizedEnhancer enhancer={endEnhancer} size={EnhancerSizes[size]} />}
             {!!displayNotificationDot && (
-                <div className="absolute top-0 right-0">
+                <div className={styles.notificationDot}>
                     <NotificationDot size={8} />
                 </div>
             )}

--- a/src/stories/cardbutton/CardButton.module.scss
+++ b/src/stories/cardbutton/CardButton.module.scss
@@ -24,7 +24,10 @@
     border-radius: var(--pte-borders-radius-rounded);
     background-color: var(--pte-new-colors-surfacePrimary);
     box-shadow: var(--pte-new-lighting-subtlePopup);
-    border: 1px solid var(--pte-new-colors-surfacePrimary);
+    // Transparent so the border never renders as a ring: the background fills the border-box in
+    // every state, so the 1px stays invisible at rest and on hover (previously it was pinned to
+    // surfacePrimary and became visible once the hover background changed).
+    border: 1px solid transparent;
 
     &:hover {
         background-color: var(--pte-new-colors-overlayStrong);

--- a/src/stories/cardbutton/CardButton.module.scss
+++ b/src/stories/cardbutton/CardButton.module.scss
@@ -24,9 +24,6 @@
     border-radius: var(--pte-borders-radius-rounded);
     background-color: var(--pte-new-colors-surfacePrimary);
     box-shadow: var(--pte-new-lighting-subtlePopup);
-    // Transparent so the border never renders as a ring: the background fills the border-box in
-    // every state, so the 1px stays invisible at rest and on hover (previously it was pinned to
-    // surfacePrimary and became visible once the hover background changed).
     border: 1px solid transparent;
 
     &:hover {

--- a/src/stories/cardbutton/CardButton.tsx
+++ b/src/stories/cardbutton/CardButton.tsx
@@ -3,7 +3,7 @@
 import type { ButtonProps as AriaButtonProps } from '@ariakit/react';
 import { Button as AriaButton } from '@ariakit/react';
 import { clsx } from 'clsx';
-import type { FC, HTMLAttributeAnchorTarget, MouseEventHandler, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, FC, HTMLAttributeAnchorTarget, MouseEventHandler, ReactNode } from 'react';
 import { TextWhenString } from '../utility';
 import styles from './CardButton.module.scss';
 
@@ -41,6 +41,14 @@ export type CardButtonProps = {
      * The contents of the Button.
      */
     children?: ReactNode | ReactNode[];
+    /**
+     * Element-specific prop overrides. `container` targets the outer wrapper, `card` targets the
+     * inner button element.
+     */
+    overrides?: {
+        container?: ComponentPropsWithoutRef<'div'>;
+        card?: AriaButtonProps;
+    };
 } & Omit<AriaButtonProps, 'children' | 'disabled' | 'onClick'>;
 
 /**
@@ -63,17 +71,20 @@ export const CardButton: FC<CardButtonProps> = ({
     children,
     disabled,
     href,
+    overrides,
     ...props
 }) => (
-    <div className={styles.container}>
+    <div {...overrides?.container} className={clsx(styles.container, overrides?.container?.className)}>
         <AriaButton
             {...props}
+            {...overrides?.card}
             className={clsx(
                 styles.card,
                 styles[kind],
                 styles[status],
                 typeof children === 'string' && styles.text,
                 props?.className,
+                overrides?.card?.className,
             )}
             aria-disabled={disabled ?? false}
             type={type}

--- a/src/stories/checkbox/Checkbox.module.scss
+++ b/src/stories/checkbox/Checkbox.module.scss
@@ -62,6 +62,10 @@
             border-color: var(--pte-new-colors-contentDisabled);
         }
 
+        &[data-status="error"] {
+            border-color: var(--pte-new-colors-inputBorderNegative);
+        }
+
         & span {
             transition: var(--pte-animations-interaction);
         }
@@ -131,6 +135,15 @@
             }
         }
     }
+
+    &.surface[data-status="error"], &.panel[data-status="error"] {
+        outline: 1px solid var(--pte-new-colors-inputBorderNegative);
+        outline-offset: -1px;
+
+        .box {
+            border-color: var(--pte-new-colors-inputBorderNegative);
+        }
+    }
 }
 
 .indicator {
@@ -174,6 +187,11 @@
         &[data-checked], &[data-state="indeterminate"] {
             background-color: var(--pte-new-colors-contentInverseTertiary);
         }
+    }
+
+    &[data-status="error"] {
+        outline: 1px solid var(--pte-new-colors-inputBorderNegative);
+        outline-offset: 2px;
     }
 
     &:hover {

--- a/src/stories/checkbox/Checkbox.tsx
+++ b/src/stories/checkbox/Checkbox.tsx
@@ -16,6 +16,12 @@ export type CheckboxProps = {
     onChange?: (checked: boolean | 'indeterminate') => void;
     disabled?: boolean;
     /**
+     * The validation status of the Checkbox. `error` renders an invalid treatment (e.g. for a
+     * required checkbox that hasn't been checked). Follows the `Input`/`Select` pattern.
+     * @default 'default'
+     */
+    status?: 'default' | 'error';
+    /**
      * Whether to hide the label text of the Checkbox. Does not apply to `kind="surface"` because there would be nothing visible.
      *
      * @default false
@@ -47,6 +53,7 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
             defaultChecked,
             onChange,
             disabled,
+            status = 'default',
             hideLabel = false,
             children,
             className,
@@ -79,6 +86,7 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
                         checked={resolvedChecked}
                         onCheckedChange={(v) => setResolvedChecked(!!v)}
                         data-disabled={disabled}
+                        data-status={status}
                         aria-details={typeof children === 'string' ? children : undefined}
                     >
                         {(kind === 'surface' || kind === 'panel') && (
@@ -114,6 +122,7 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
                         onChange={setResolvedChecked}
                         className={styles.switchContainer}
                         data-disabled={disabled}
+                        data-status={status}
                         id={inputID}
                         aria-details={typeof children === 'string' ? children : undefined}
                     >

--- a/src/stories/checkbox/Checkbox.tsx
+++ b/src/stories/checkbox/Checkbox.tsx
@@ -2,8 +2,8 @@
 import { Switch } from '@headlessui/react';
 import * as RadixCheckbox from '@radix-ui/react-checkbox';
 import { clsx } from 'clsx';
-import type { FC, ReactNode } from 'react';
-import { useId } from 'react';
+import type { ReactNode } from 'react';
+import { forwardRef, useId } from 'react';
 import { useControllableState } from '../../helpers/useControllableState';
 import { Check, Icon } from '../icon';
 import { TextWhenString, VisuallyHidden } from '../utility';
@@ -39,85 +39,94 @@ export type CheckboxProps = {
  * ```
  * @constructor
  */
-export const Checkbox: FC<CheckboxProps> = ({
-    kind = 'default',
-    checked,
-    defaultChecked,
-    onChange,
-    disabled,
-    hideLabel = false,
-    children,
-    className,
-    ...props
-}) => {
-    const inputID = useId();
-    const [resolvedChecked, setResolvedChecked] = useControllableState({
-        value: checked,
-        defaultValue: defaultChecked,
-        onChange: onChange as ((value: boolean) => void) | undefined,
-    });
-    return (
-        <label
-            htmlFor={inputID}
-            className={clsx(
-                styles.container,
-                disabled && styles.disabled,
-                className,
-                resolvedChecked && styles.checked,
-            )}
-            {...props}
-        >
-            {(kind === 'default' || kind === 'surface' || kind === 'panel') && (
-                <RadixCheckbox.Root
-                    id={inputID}
-                    className={clsx(styles.root, styles[kind])}
-                    checked={resolvedChecked}
-                    onCheckedChange={(v) => setResolvedChecked(!!v)}
-                    data-disabled={disabled}
-                    aria-details={typeof children === 'string' ? children : undefined}
-                >
-                    {(kind === 'surface' || kind === 'panel') && (
-                        <TextWhenString kind="paragraphXSmall">{children}</TextWhenString>
-                    )}
-                    {kind === 'panel' && <div className={styles.box} />}
-                    <RadixCheckbox.Indicator className={styles.indicator}>
-                        {(kind === 'default' || kind === 'panel') && (
-                            <svg
-                                width={14}
-                                height={14}
-                                viewBox="0 0 14 14"
-                                fill="none"
-                                xmlns="http://www.w3.org/2000/svg"
-                            >
-                                <path
-                                    className={styles.checkSvg}
-                                    data-disabled={disabled}
-                                    d="M0.333374 0.333252V13.6666H13.6667V0.333252H0.333374ZM6.00004 10.3999L2.26672 6.66658L3.66671 5.26658L5.93339 7.53325L10.2 3.26658L11.6001 4.66659L6.00004 10.3999Z"
-                                />
-                            </svg>
+export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(
+    (
+        {
+            kind = 'default',
+            checked,
+            defaultChecked,
+            onChange,
+            disabled,
+            hideLabel = false,
+            children,
+            className,
+            ...props
+        },
+        ref,
+    ) => {
+        const inputID = useId();
+        const [resolvedChecked, setResolvedChecked] = useControllableState({
+            value: checked,
+            defaultValue: defaultChecked,
+            onChange: onChange as ((value: boolean) => void) | undefined,
+        });
+        return (
+            <label
+                htmlFor={inputID}
+                className={clsx(
+                    styles.container,
+                    disabled && styles.disabled,
+                    className,
+                    resolvedChecked && styles.checked,
+                )}
+                {...props}
+            >
+                {(kind === 'default' || kind === 'surface' || kind === 'panel') && (
+                    <RadixCheckbox.Root
+                        ref={ref}
+                        id={inputID}
+                        className={clsx(styles.root, styles[kind])}
+                        checked={resolvedChecked}
+                        onCheckedChange={(v) => setResolvedChecked(!!v)}
+                        data-disabled={disabled}
+                        aria-details={typeof children === 'string' ? children : undefined}
+                    >
+                        {(kind === 'surface' || kind === 'panel') && (
+                            <TextWhenString kind="paragraphXSmall">{children}</TextWhenString>
                         )}
-                        {kind === 'surface' && (
-                            <Icon icon={Check} size={12.8} data-disabled={disabled} className={styles.checkIcon} />
-                        )}
-                    </RadixCheckbox.Indicator>
-                </RadixCheckbox.Root>
-            )}
-            {kind === 'switch' && (
-                <Switch
-                    checked={resolvedChecked}
-                    onChange={setResolvedChecked}
-                    className={styles.switchContainer}
-                    data-disabled={disabled}
-                    id={inputID}
-                    aria-details={typeof children === 'string' ? children : undefined}
-                >
-                    <span aria-hidden="true" className={clsx(styles.knob, resolvedChecked && styles.knobChecked)} />
-                </Switch>
-            )}
-            {(kind === 'default' || kind === 'switch') && !hideLabel && (
-                <TextWhenString kind="paragraphXSmall">{children}</TextWhenString>
-            )}
-            {hideLabel && <VisuallyHidden>{children}</VisuallyHidden>}
-        </label>
-    );
-};
+                        {kind === 'panel' && <div className={styles.box} />}
+                        <RadixCheckbox.Indicator className={styles.indicator}>
+                            {(kind === 'default' || kind === 'panel') && (
+                                <svg
+                                    width={14}
+                                    height={14}
+                                    viewBox="0 0 14 14"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                >
+                                    <path
+                                        className={styles.checkSvg}
+                                        data-disabled={disabled}
+                                        d="M0.333374 0.333252V13.6666H13.6667V0.333252H0.333374ZM6.00004 10.3999L2.26672 6.66658L3.66671 5.26658L5.93339 7.53325L10.2 3.26658L11.6001 4.66659L6.00004 10.3999Z"
+                                    />
+                                </svg>
+                            )}
+                            {kind === 'surface' && (
+                                <Icon icon={Check} size={12.8} data-disabled={disabled} className={styles.checkIcon} />
+                            )}
+                        </RadixCheckbox.Indicator>
+                    </RadixCheckbox.Root>
+                )}
+                {kind === 'switch' && (
+                    <Switch
+                        ref={ref}
+                        checked={resolvedChecked}
+                        onChange={setResolvedChecked}
+                        className={styles.switchContainer}
+                        data-disabled={disabled}
+                        id={inputID}
+                        aria-details={typeof children === 'string' ? children : undefined}
+                    >
+                        <span aria-hidden="true" className={clsx(styles.knob, resolvedChecked && styles.knobChecked)} />
+                    </Switch>
+                )}
+                {(kind === 'default' || kind === 'switch') && !hideLabel && (
+                    <TextWhenString kind="paragraphXSmall">{children}</TextWhenString>
+                )}
+                {hideLabel && <VisuallyHidden>{children}</VisuallyHidden>}
+            </label>
+        );
+    },
+);
+
+Checkbox.displayName = 'Checkbox';

--- a/src/stories/codeinput/CodeInput.tsx
+++ b/src/stories/codeinput/CodeInput.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { clsx } from 'clsx';
-import type { ChangeEvent, ClipboardEvent, FC, KeyboardEvent } from 'react';
-import { useCallback, useEffect, useRef } from 'react';
+import type { ChangeEvent, ClipboardEvent, KeyboardEvent } from 'react';
+import { forwardRef, useCallback, useEffect, useRef } from 'react';
 import styles from './CodeInput.module.scss';
 
 export type CodeInputProps = {
@@ -51,110 +51,122 @@ export type CodeInputProps = {
  * ```
  * @constructor
  */
-export const CodeInput: FC<CodeInputProps> = ({
-    value,
-    onChange,
-    onComplete,
-    length = 6,
-    status = 'default',
-    disabled = false,
-    loading = false,
-    autoFocus = false,
-    'aria-label': ariaLabel = 'Verification code',
-}) => {
-    const inputsRef = useRef<Array<HTMLInputElement | null>>([]);
-    const digits = value.split('').slice(0, length);
-
-    const focusAt = useCallback(
-        (index: number) => {
-            const clamped = Math.max(0, Math.min(index, length - 1));
-            const input = inputsRef.current[clamped];
-            input?.focus();
-            input?.select();
+export const CodeInput = forwardRef<HTMLInputElement, CodeInputProps>(
+    (
+        {
+            value,
+            onChange,
+            onComplete,
+            length = 6,
+            status = 'default',
+            disabled = false,
+            loading = false,
+            autoFocus = false,
+            'aria-label': ariaLabel = 'Verification code',
         },
-        [length],
-    );
+        ref,
+    ) => {
+        const inputsRef = useRef<Array<HTMLInputElement | null>>([]);
+        const digits = value.split('').slice(0, length);
 
-    useEffect(() => {
-        if (autoFocus) focusAt(0);
-    }, [autoFocus, focusAt]);
+        const focusAt = useCallback(
+            (index: number) => {
+                const clamped = Math.max(0, Math.min(index, length - 1));
+                const input = inputsRef.current[clamped];
+                input?.focus();
+                input?.select();
+            },
+            [length],
+        );
 
-    const emit = useCallback(
-        (next: string) => {
-            const sliced = next.slice(0, length);
-            onChange(sliced);
-            if (sliced.length === length) onComplete?.(sliced);
-        },
-        [length, onChange, onComplete],
-    );
+        useEffect(() => {
+            if (autoFocus) focusAt(0);
+        }, [autoFocus, focusAt]);
 
-    const handleChange = (index: number) => (event: ChangeEvent<HTMLInputElement>) => {
-        const typed = event.target.value.replace(/\D/g, '');
-        if (!typed) return;
-        const chars = value.split('');
-        let cursor = index;
-        for (const char of typed) {
-            if (cursor >= length) break;
-            chars[cursor] = char;
-            cursor += 1;
-        }
-        emit(chars.join(''));
-        focusAt(cursor);
-    };
+        const emit = useCallback(
+            (next: string) => {
+                const sliced = next.slice(0, length);
+                onChange(sliced);
+                if (sliced.length === length) onComplete?.(sliced);
+            },
+            [length, onChange, onComplete],
+        );
 
-    const handleKeyDown = (index: number) => (event: KeyboardEvent<HTMLInputElement>) => {
-        const chars = value.split('');
-        if (event.key === 'Backspace') {
-            event.preventDefault();
-            if (chars[index]) {
-                chars[index] = '';
-                emit(chars.join(''));
-            } else if (index > 0) {
-                chars[index - 1] = '';
-                emit(chars.join(''));
-                focusAt(index - 1);
+        const handleChange = (index: number) => (event: ChangeEvent<HTMLInputElement>) => {
+            const typed = event.target.value.replace(/\D/g, '');
+            if (!typed) return;
+            const chars = value.split('');
+            let cursor = index;
+            for (const char of typed) {
+                if (cursor >= length) break;
+                chars[cursor] = char;
+                cursor += 1;
             }
-        } else if (event.key === 'ArrowLeft') {
-            event.preventDefault();
-            focusAt(index - 1);
-        } else if (event.key === 'ArrowRight') {
-            event.preventDefault();
-            focusAt(index + 1);
-        }
-    };
+            emit(chars.join(''));
+            focusAt(cursor);
+        };
 
-    const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
-        event.preventDefault();
-        const pasted = event.clipboardData.getData('text').replace(/\D/g, '').slice(0, length);
-        if (!pasted) return;
-        emit(pasted);
-        focusAt(pasted.length);
-    };
+        const handleKeyDown = (index: number) => (event: KeyboardEvent<HTMLInputElement>) => {
+            const chars = value.split('');
+            if (event.key === 'Backspace') {
+                event.preventDefault();
+                if (chars[index]) {
+                    chars[index] = '';
+                    emit(chars.join(''));
+                } else if (index > 0) {
+                    chars[index - 1] = '';
+                    emit(chars.join(''));
+                    focusAt(index - 1);
+                }
+            } else if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                focusAt(index - 1);
+            } else if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                focusAt(index + 1);
+            }
+        };
 
-    return (
-        <div className={clsx(styles.container, loading && styles.loading)} role="group" aria-label={ariaLabel}>
-            {Array.from({ length }).map((_, index) => (
-                <input
-                    // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length positional code segments are stable
-                    key={index}
-                    ref={(element) => {
-                        inputsRef.current[index] = element;
-                    }}
-                    className={clsx(styles.segment, status === 'error' && styles.error)}
-                    type="text"
-                    inputMode="numeric"
-                    autoComplete={index === 0 ? 'one-time-code' : 'off'}
-                    maxLength={1}
-                    disabled={disabled}
-                    readOnly={loading}
-                    value={digits[index] ?? ''}
-                    aria-label={`Digit ${index + 1}`}
-                    onChange={handleChange(index)}
-                    onKeyDown={handleKeyDown(index)}
-                    onPaste={handlePaste}
-                    onFocus={(event) => event.target.select()}
-                />
-            ))}
-        </div>
-    );
-};
+        const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+            event.preventDefault();
+            const pasted = event.clipboardData.getData('text').replace(/\D/g, '').slice(0, length);
+            if (!pasted) return;
+            emit(pasted);
+            focusAt(pasted.length);
+        };
+
+        return (
+            <div className={clsx(styles.container, loading && styles.loading)} role="group" aria-label={ariaLabel}>
+                {Array.from({ length }).map((_, index) => (
+                    <input
+                        // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length positional code segments are stable
+                        key={index}
+                        ref={(element) => {
+                            inputsRef.current[index] = element;
+                            // Forward the first cell so form libraries can focus the code input by ref.
+                            if (index === 0) {
+                                if (typeof ref === 'function') ref(element);
+                                else if (ref) ref.current = element;
+                            }
+                        }}
+                        className={clsx(styles.segment, status === 'error' && styles.error)}
+                        type="text"
+                        inputMode="numeric"
+                        autoComplete={index === 0 ? 'one-time-code' : 'off'}
+                        maxLength={1}
+                        disabled={disabled}
+                        readOnly={loading}
+                        value={digits[index] ?? ''}
+                        aria-label={`Digit ${index + 1}`}
+                        onChange={handleChange(index)}
+                        onKeyDown={handleKeyDown(index)}
+                        onPaste={handlePaste}
+                        onFocus={(event) => event.target.select()}
+                    />
+                ))}
+            </div>
+        );
+    },
+);
+
+CodeInput.displayName = 'CodeInput';

--- a/src/stories/combobox/Combobox.tsx
+++ b/src/stories/combobox/Combobox.tsx
@@ -10,7 +10,7 @@ import {
     Combobox as HCombobox,
 } from '@headlessui/react';
 import { clsx } from 'clsx';
-import type { ComponentPropsWithoutRef, CSSProperties, MouseEvent, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, CSSProperties, MouseEvent, ReactNode, Ref } from 'react';
 import { useCallback, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { OpenChangeEffect } from '../../helpers/OpenChangeEffect';
 import { MemoizedEnhancer } from '../../helpers/renderEnhancer';
@@ -132,6 +132,11 @@ export type ComboboxProps<T extends Record<string, any>> = {
         endEnhancerContainer?: ComponentPropsWithoutRef<'div'>;
         clearButton?: ButtonProps;
     };
+    /**
+     * Ref forwarded to the underlying combobox `<input>` element. Lets form libraries (e.g.
+     * react-hook-form's `field.ref` / `setFocus`) focus the combobox when its field is invalid.
+     */
+    ref?: Ref<HTMLInputElement>;
 } & Omit<InputProps, 'type' | 'overrides'>;
 
 /**
@@ -176,6 +181,7 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
     hasOptionBorder = false,
     hideOptionsInitially = false,
     overrides,
+    ref,
 }: ComboboxProps<T>) {
     const inputID = useId();
     const [resolvedValue, setResolvedValue] = useControllableState<Option<T> | null>({
@@ -192,9 +198,17 @@ export function Combobox<T extends Record<string, any> = Record<string, any>>({
         containerElRef.current = node;
     }, []);
 
-    const inputRef = useCallback((node: HTMLInputElement | null) => {
-        inputElRef.current = node;
-    }, []);
+    const inputRef = useCallback(
+        (node: HTMLInputElement | null) => {
+            inputElRef.current = node;
+            if (typeof ref === 'function') {
+                ref(node);
+            } else if (ref) {
+                ref.current = node;
+            }
+        },
+        [ref],
+    );
 
     useLayoutEffect(() => {
         if (containerElRef.current && inputElRef.current) {

--- a/src/stories/combobox/Combobox.tsx
+++ b/src/stories/combobox/Combobox.tsx
@@ -27,7 +27,7 @@ import { Text } from '../text';
 import { pget, theme } from '../theme';
 import { TextWhenString } from '../utility';
 
-export type Option<T extends Record<string, any> = Record<string, any>> =
+export type Option<T extends Record<string, unknown> = Record<string, unknown>> =
     | {
           id: string;
           node: ReactNode;
@@ -39,7 +39,7 @@ export type Option<T extends Record<string, any> = Record<string, any>> =
           metadata?: T;
       };
 
-export type ComboboxProps<T extends Record<string, any>> = {
+export type ComboboxProps<T extends Record<string, unknown>> = {
     /**
      * The  {@link Option}s to render in the select box.
      *
@@ -155,7 +155,7 @@ export type ComboboxProps<T extends Record<string, any>> = {
  * ```
  * @constructor
  */
-export function Combobox<T extends Record<string, any> = Record<string, any>>({
+export function Combobox<T extends Record<string, unknown> = Record<string, unknown>>({
     options,
     value,
     defaultValue,

--- a/src/stories/combobox/Combobox.tsx
+++ b/src/stories/combobox/Combobox.tsx
@@ -11,7 +11,7 @@ import {
 } from '@headlessui/react';
 import { clsx } from 'clsx';
 import type { ComponentPropsWithoutRef, CSSProperties, MouseEvent, ReactNode, Ref } from 'react';
-import { useCallback, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { OpenChangeEffect } from '../../helpers/OpenChangeEffect';
 import { MemoizedEnhancer } from '../../helpers/renderEnhancer';
 import { useControllableState } from '../../helpers/useControllableState';
@@ -198,17 +198,24 @@ export function Combobox<T extends Record<string, unknown> = Record<string, unkn
         containerElRef.current = node;
     }, []);
 
-    const inputRef = useCallback(
-        (node: HTMLInputElement | null) => {
-            inputElRef.current = node;
-            if (typeof ref === 'function') {
-                ref(node);
-            } else if (ref) {
-                ref.current = node;
-            }
-        },
-        [ref],
-    );
+    const inputRef = useCallback((node: HTMLInputElement | null) => {
+        inputElRef.current = node;
+    }, []);
+
+    // The text input only renders when the selected node is a string/empty; a non-string node
+    // (e.g. a <Text> element) replaces it, unmounting the input and nulling its ref. Forward the
+    // external ref to whichever focusable element is currently mounted — the input, or the
+    // always-mounted container — so react-hook-form's `setFocus` works in both states.
+    const showInput = !(resolvedValue?.node && typeof resolvedValue.node !== 'string');
+    useEffect(() => {
+        if (!ref) return;
+        const target = (showInput ? inputElRef.current : containerElRef.current) as HTMLInputElement | null;
+        if (typeof ref === 'function') {
+            ref(target);
+        } else {
+            ref.current = target;
+        }
+    }, [ref, showInput]);
 
     useLayoutEffect(() => {
         if (containerElRef.current && inputElRef.current) {

--- a/src/stories/drawer/Drawer.stories.tsx
+++ b/src/stories/drawer/Drawer.stories.tsx
@@ -222,7 +222,7 @@ export const WithSelectDropdown: Story = {
                             label="Country"
                             placeholder="Select a country"
                             value={selected}
-                            onChange={setSelected}
+                            onChange={(option) => setSelected(option?.id ?? null)}
                             options={[
                                 { id: 'us', node: 'United States' },
                                 { id: 'uk', node: 'United Kingdom' },

--- a/src/stories/drawer/Drawer.tsx
+++ b/src/stories/drawer/Drawer.tsx
@@ -124,6 +124,15 @@ export type DrawerProps<T extends string[] | readonly string[] = string[]> = {
      */
     pageTransition?: DrawerPageTransition;
     /**
+     * Callback fired once the target page's content is mounted and its enter transition has
+     * completed (for `crossfade`/`slide`), or immediately on change for `none`. Lets consumers
+     * focus a field on a newly-navigated page deterministically instead of polling animation
+     * frames. Only fires for paginated drawers.
+     *
+     * @param pageID - The id of the page that just entered.
+     */
+    onPageEntered?: (pageID: T[number]) => void;
+    /**
      * Show a progress bar at the top of the bottom panel. Requires `pagination` to be set.
      * The bar auto-fills based on the current page position.
      *
@@ -231,6 +240,7 @@ const DrawerInner = <T extends string[] | readonly string[] = string[]>({
     size = 'default',
     pagination,
     pageTransition = 'crossfade',
+    onPageEntered,
     progressBar,
     overlayStyle = 'grey',
     additionalActions,
@@ -270,6 +280,15 @@ const DrawerInner = <T extends string[] | readonly string[] = string[]>({
     }, [showBottomPanel, appendEntries]);
 
     const [loadedPage, setLoadedPage] = useState<string | null>(pagination?.currentPage ?? null);
+
+    // `none` switches pages instantly (content is always mounted), so there is no enter transition
+    // to hook — signal the page change directly. `crossfade`/`slide` fire onPageEntered from their
+    // own transition-complete handlers below.
+    const currentPage = pagination?.currentPage;
+    useEffect(() => {
+        if (pageTransition !== 'none' || currentPage == null) return;
+        onPageEntered?.(currentPage);
+    }, [pageTransition, currentPage, onPageEntered]);
 
     const pageEntries = useMemo(() => {
         if (!isPaginated || !pagination || !children) return null;
@@ -315,6 +334,7 @@ const DrawerInner = <T extends string[] | readonly string[] = string[]>({
                                 leaveFrom={styles.leaveFromOpacity}
                                 leaveTo={styles.leaveToOpacity}
                                 afterLeave={() => setLoadedPage(pagination.currentPage)}
+                                afterEnter={() => onPageEntered?.(page.id as T[number])}
                                 className={overrides?.contentChildrenChildren?.className}
                             >
                                 {page.child}
@@ -338,6 +358,9 @@ const DrawerInner = <T extends string[] | readonly string[] = string[]>({
                                             type: 'tween',
                                             duration: 0.3,
                                             ease: [0.32, 0.72, 0, 1],
+                                        }}
+                                        onAnimationComplete={() => {
+                                            if (isActive) onPageEntered?.(page.id as T[number]);
                                         }}
                                         className={clsx(
                                             styles.pageStackItem,
@@ -364,6 +387,7 @@ const DrawerInner = <T extends string[] | readonly string[] = string[]>({
         pageTransition,
         loadedPage,
         activePageIndex,
+        onPageEntered,
         overrides?.contentChildrenChildren?.className,
     ]);
 

--- a/src/stories/field/Field.test.tsx
+++ b/src/stories/field/Field.test.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom';
 import { render, screen } from '../../test/render';
 import { Field } from './Field';
 
@@ -112,6 +113,29 @@ describe('Field', () => {
         const label = screen.getByText('Click me');
         await user.click(label);
         expect(screen.getByTestId('focusable')).toHaveFocus();
+    });
+
+    it('does not re-trigger the input for clicks from portaled descendants (ENG-1958)', async () => {
+        // Headless UI options/menu items render into document.body via Floating UI. React
+        // synthetic clicks bubble through the React tree to Field's container onClick even though
+        // the option is outside Field's DOM subtree. The container must ignore those so it doesn't
+        // programmatically re-click the trigger and reopen a just-dismissed dropdown (touch).
+        const onTriggerClick = vi.fn();
+        const { user } = render(
+            <Field label="Country" htmlFor="portal-trigger">
+                <button id="portal-trigger" type="button" onClick={onTriggerClick}>
+                    Trigger
+                </button>
+                {createPortal(
+                    <button data-testid="portaled-option" type="button">
+                        Option
+                    </button>,
+                    document.body,
+                )}
+            </Field>,
+        );
+        await user.click(screen.getByTestId('portaled-option'));
+        expect(onTriggerClick).not.toHaveBeenCalled();
     });
 
     it('does not focus the input when disabled', async () => {

--- a/src/stories/field/Field.test.tsx
+++ b/src/stories/field/Field.test.tsx
@@ -115,11 +115,7 @@ describe('Field', () => {
         expect(screen.getByTestId('focusable')).toHaveFocus();
     });
 
-    it('does not re-trigger the input for clicks from portaled descendants (ENG-1958)', async () => {
-        // Headless UI options/menu items render into document.body via Floating UI. React
-        // synthetic clicks bubble through the React tree to Field's container onClick even though
-        // the option is outside Field's DOM subtree. The container must ignore those so it doesn't
-        // programmatically re-click the trigger and reopen a just-dismissed dropdown (touch).
+    it('ignores clicks from portaled descendants', async () => {
         const onTriggerClick = vi.fn();
         const { user } = render(
             <Field label="Country" htmlFor="portal-trigger">

--- a/src/stories/field/Field.tsx
+++ b/src/stories/field/Field.tsx
@@ -120,12 +120,17 @@ export const Field: FC<PropsWithChildren<FieldProps>> = ({
                 // className,
             )}
             onClick={(e) => {
-                if (typeof window !== 'undefined' && htmlFor) {
-                    const input = document.getElementById(htmlFor);
-                    if (input && !disabled && !input.contains(e.target as Node)) {
-                        if (input.tagName === 'BUTTON') input.click();
-                        else input.focus();
-                    }
+                if (typeof window === 'undefined' || !htmlFor) return;
+                // Skip clicks originating from portaled descendants — e.g. Headless UI
+                // ListboxOptions / ComboboxOptions / MenuItems rendered into document.body via
+                // Floating UI. React synthetic events still bubble through the React tree across
+                // portals, but those elements are outside Field's DOM subtree, so re-focusing the
+                // input here would reopen a dropdown the user just dismissed (notably on touch).
+                if (!(e.currentTarget as Node).contains(e.target as Node)) return;
+                const input = document.getElementById(htmlFor);
+                if (input && !disabled && !input.contains(e.target as Node)) {
+                    if (input.tagName === 'BUTTON') input.click();
+                    else input.focus();
                 }
             }}
         >

--- a/src/stories/field/Field.tsx
+++ b/src/stories/field/Field.tsx
@@ -121,11 +121,6 @@ export const Field: FC<PropsWithChildren<FieldProps>> = ({
             )}
             onClick={(e) => {
                 if (typeof window === 'undefined' || !htmlFor) return;
-                // Skip clicks originating from portaled descendants — e.g. Headless UI
-                // ListboxOptions / ComboboxOptions / MenuItems rendered into document.body via
-                // Floating UI. React synthetic events still bubble through the React tree across
-                // portals, but those elements are outside Field's DOM subtree, so re-focusing the
-                // input here would reopen a dropdown the user just dismissed (notably on touch).
                 if (!(e.currentTarget as Node).contains(e.target as Node)) return;
                 const input = document.getElementById(htmlFor);
                 if (input && !disabled && !input.contains(e.target as Node)) {

--- a/src/stories/input/Input.tsx
+++ b/src/stories/input/Input.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { clsx } from 'clsx';
-import type { ComponentPropsWithoutRef, FC, ForwardedRef } from 'react';
+import type { ComponentPropsWithoutRef, ForwardedRef } from 'react';
 import { forwardRef, useId } from 'react';
 import { MemoizedEnhancer } from '../../helpers/renderEnhancer';
 import type { Enhancer } from '../../types/Enhancer';
@@ -86,7 +86,7 @@ export type InputProps = {
  * ```
  * @constructor
  */
-export const Input: FC<InputProps & ComponentPropsWithoutRef<'input'>> = forwardRef(
+export const Input = forwardRef<HTMLInputElement, InputProps & ComponentPropsWithoutRef<'input'>>(
     (
         {
             label,

--- a/src/stories/markdowneditor/MarkdownEditor.tsx
+++ b/src/stories/markdowneditor/MarkdownEditor.tsx
@@ -2,8 +2,8 @@
 
 import { EditorContent } from '@tiptap/react';
 import { clsx } from 'clsx';
-import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
-import { useMemo } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { forwardRef, useImperativeHandle, useMemo } from 'react';
 import type { MarkdownSize } from '../markdown';
 import type { MarkdownEditorFeature } from './features';
 import { ALL_FEATURES } from './features';
@@ -52,6 +52,15 @@ export type MarkdownEditorProps = {
 };
 
 /**
+ * Imperative handle exposed via `ref`. Lets consumers focus the editor programmatically (e.g.
+ * react-hook-form's `setFocus`) without reaching into the underlying Tiptap instance.
+ */
+export type MarkdownEditorHandle = {
+    /** Move focus into the editor's content area. */
+    focus: () => void;
+};
+
+/**
  * A WYSIWYG markdown editor built on Tiptap, styled with Paris design tokens.
  * It pairs with the read-only `<Markdown>` component as its write counterpart.
  *
@@ -78,20 +87,23 @@ export type MarkdownEditorProps = {
  *
  * @constructor
  */
-export const MarkdownEditor: FC<MarkdownEditorProps> = ({
-    value,
-    onChange,
-    features = ALL_FEATURES,
-    placeholder,
-    size = 'paragraphSmall',
-    editable = true,
-    autofocus = false,
-    handleImageUpload,
-    className,
-    status = 'default',
-    overrides,
-    children,
-}) => {
+export const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(function MarkdownEditor(
+    {
+        value,
+        onChange,
+        features = ALL_FEATURES,
+        placeholder,
+        size = 'paragraphSmall',
+        editable = true,
+        autofocus = false,
+        handleImageUpload,
+        className,
+        status = 'default',
+        overrides,
+        children,
+    },
+    ref,
+) {
     const { editor, featureSet } = useMarkdownEditor({
         value,
         onChange,
@@ -100,6 +112,8 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
         editable,
         autofocus,
     });
+
+    useImperativeHandle(ref, () => ({ focus: () => editor?.commands.focus() }), [editor]);
 
     const contextValue = useMemo(
         () => ({ editor, features: featureSet, handleImageUpload }),
@@ -130,4 +144,4 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
             </div>
         </MarkdownEditorContext.Provider>
     );
-};
+});

--- a/src/stories/menu/Menu.module.scss
+++ b/src/stories/menu/Menu.module.scss
@@ -22,8 +22,6 @@
     opacity: 1;
     transform: translateY(0);
 
-    // Hide the popup entirely when it has no items, otherwise the empty container still paints its
-    // background, border and drop shadow as a stray floating box (same issue as ENG-1558 on Select).
     &:empty {
         display: none;
     }

--- a/src/stories/menu/Menu.module.scss
+++ b/src/stories/menu/Menu.module.scss
@@ -22,6 +22,12 @@
     opacity: 1;
     transform: translateY(0);
 
+    // Hide the popup entirely when it has no items, otherwise the empty container still paints its
+    // background, border and drop shadow as a stray floating box (same issue as ENG-1558 on Select).
+    &:empty {
+        display: none;
+    }
+
     &[data-closed] {
         opacity: 0;
         transform: translateY(-8px);

--- a/src/stories/menu/Menu.tsx
+++ b/src/stories/menu/Menu.tsx
@@ -60,24 +60,33 @@ export const MenuButton: FC<MenuButtonProps<React.ElementType>> = ({ className, 
 /**
  * Container for menu item options, rendering the list of `MenuItem` components.
  *
- * Positions the menu items relative to the `MenuButton` based on the `position` prop.
+ * Positions the menu items relative to the `MenuButton` based on the `position` and
+ * `verticalPosition` props.
  *
- * @param position - Controls the positioning of the menu items ('left' or 'right').
+ * @param position - Controls the horizontal alignment of the menu items ('left' or 'right').
+ * @param verticalPosition - Controls whether the menu opens below or above the button ('bottom' or 'top').
  */
 export const MenuItems: FC<
     MenuItemsProps<React.ElementType> & {
         position?: 'left' | 'right';
+        verticalPosition?: 'bottom' | 'top';
     }
-> = ({ className, children, position = 'left', ...props }) => (
-    <HMenuItems
-        transition
-        anchor={position === 'left' ? 'bottom start' : 'bottom end'}
-        className={clsx(styles.menuItems, className)}
-        {...props}
-    >
-        {children}
-    </HMenuItems>
-);
+> = ({ className, children, position = 'left', verticalPosition = 'bottom', ...props }) => {
+    const anchor =
+        verticalPosition === 'top'
+            ? position === 'left'
+                ? 'top start'
+                : 'top end'
+            : position === 'left'
+              ? 'bottom start'
+              : 'bottom end';
+
+    return (
+        <HMenuItems transition anchor={anchor} className={clsx(styles.menuItems, className)} {...props}>
+            {children}
+        </HMenuItems>
+    );
+};
 
 /**
  * Represents an individual item within a `MenuItems` container.

--- a/src/stories/select/Select.module.scss
+++ b/src/stories/select/Select.module.scss
@@ -43,6 +43,13 @@
 
     transition: opacity var(--pte-animations-interaction), transform var(--pte-animations-interaction);
 
+    // Hide the popup entirely when there are no options to show, otherwise the empty container
+    // still paints its background, border and drop shadow — a stray floating shadow below an
+    // engaged field with no dropdown (ENG-1558).
+    &:empty {
+        display: none;
+    }
+
     &[data-closed] {
         opacity: 0;
         transform: translateY(-8px);

--- a/src/stories/select/Select.module.scss
+++ b/src/stories/select/Select.module.scss
@@ -43,9 +43,6 @@
 
     transition: opacity var(--pte-animations-interaction), transform var(--pte-animations-interaction);
 
-    // Hide the popup entirely when there are no options to show, otherwise the empty container
-    // still paints its background, border and drop shadow — a stray floating shadow below an
-    // engaged field with no dropdown (ENG-1558).
     &:empty {
         display: none;
     }

--- a/src/stories/select/Select.stories.ts
+++ b/src/stories/select/Select.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { createElement, useState } from 'react';
 import { Text } from '../text';
+import type { Option } from './Select';
 import { Select } from './Select';
 
 const meta: Meta<typeof Select> = {
@@ -27,12 +28,13 @@ const render: Story['render'] = function Render(args) {
                 ? {
                       ...args,
                       value: selectedMultiple,
-                      onChange: (value: string[] | null) => setSelectedMultiple(value),
+                      onChange: (options: Option[] | null) =>
+                          setSelectedMultiple(options ? options.map((o) => o.id) : null),
                   }
                 : {
                       ...args,
                       value: selected,
-                      onChange: (value: string | null) => setSelected(value),
+                      onChange: (option: Option | null) => setSelected(option?.id ?? null),
                   },
         ),
     );

--- a/src/stories/select/Select.test.tsx
+++ b/src/stories/select/Select.test.tsx
@@ -16,9 +16,9 @@ function ControlledSelect(props: Partial<React.ComponentProps<typeof Select>>) {
         <Select
             options={options}
             value={value}
-            onChange={(v) => {
-                setValue(v);
-                (props.onChange as (v: string | null) => void)?.(v);
+            onChange={(option) => {
+                setValue(option?.id ?? null);
+                (props.onChange as (option: Option | null) => void)?.(option);
             }}
             {...props}
         />
@@ -31,9 +31,9 @@ function ControlledMultiSelect(props: Partial<React.ComponentProps<typeof Select
         <Select
             options={options}
             value={value}
-            onChange={(v) => {
-                setValue(v as string[]);
-                (props.onChange as (v: string[] | null) => void)?.(v as string[] | null);
+            onChange={(selected) => {
+                setValue(selected ? selected.map((o) => o.id) : []);
+                (props.onChange as (selected: Option[] | null) => void)?.(selected);
             }}
             multiple
             {...props}
@@ -86,7 +86,7 @@ describe('Select', () => {
             });
 
             await user.click(screen.getByText('EP'));
-            expect(handleChange).toHaveBeenCalledWith('2');
+            expect(handleChange).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }));
         });
 
         it('displays selected option text after selection', async () => {
@@ -166,7 +166,7 @@ describe('Select', () => {
             });
 
             await user.click(screen.getByText('Single'));
-            expect(handleChange).toHaveBeenCalled();
+            expect(handleChange).toHaveBeenCalledWith([expect.objectContaining({ id: '1' })]);
         });
     });
 
@@ -195,7 +195,7 @@ describe('Select', () => {
             const { user } = render(<ControlledSelect kind="radio" onChange={handleChange} />);
 
             await user.click(screen.getByText('EP'));
-            expect(handleChange).toHaveBeenCalledWith('2');
+            expect(handleChange).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }));
         });
     });
 
@@ -211,7 +211,7 @@ describe('Select', () => {
             const { user } = render(<ControlledSelect kind="card" onChange={handleChange} />);
 
             await user.click(screen.getByText('EP'));
-            expect(handleChange).toHaveBeenCalledWith('2');
+            expect(handleChange).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }));
         });
     });
 
@@ -227,7 +227,7 @@ describe('Select', () => {
             const { user } = render(<ControlledSelect kind="segmented" onChange={handleChange} />);
 
             await user.click(screen.getByText('EP'));
-            expect(handleChange).toHaveBeenCalledWith('2');
+            expect(handleChange).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }));
         });
     });
 
@@ -267,7 +267,7 @@ describe('Select', () => {
             });
             await user.click(screen.getByText('EP'));
 
-            expect(handleChange).toHaveBeenCalledWith('2');
+            expect(handleChange).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }));
         });
 
         it('updates selection without external state (radio)', async () => {

--- a/src/stories/select/Select.tsx
+++ b/src/stories/select/Select.tsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions, Radio, RadioGroup } from '@headlessui/react';
 import { clsx } from 'clsx';
 import { motion } from 'framer-motion';
-import type { ComponentPropsWithoutRef, CSSProperties, ForwardedRef, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, CSSProperties, ForwardedRef, ReactNode, RefAttributes } from 'react';
 import { forwardRef, useId } from 'react';
 import { OpenChangeEffect } from '../../helpers/OpenChangeEffect';
 import { MemoizedEnhancer } from '../../helpers/renderEnhancer';
@@ -20,13 +20,13 @@ import { pget, theme } from '../theme';
 import { TextWhenString } from '../utility';
 import styles from './Select.module.scss';
 
-export type Option<T = Record<string, any>> = {
+export type Option<T extends Record<string, unknown> = Record<string, unknown>> = {
     id: string;
     node: ReactNode;
     disabled?: boolean;
     metadata?: T;
 };
-export type CommonSelectProps<T = Record<string, any>> = {
+export type CommonSelectProps<T extends Record<string, unknown> = Record<string, unknown>> = {
     /**
      * The  {@link Option}s to render in the select box.
      *
@@ -68,7 +68,7 @@ export type CommonSelectProps<T = Record<string, any>> = {
     };
 } & Omit<InputProps, 'type' | 'overrides'>;
 
-export type SingleSelectProps<T = Record<string, any>> = {
+export type SingleSelectProps<T extends Record<string, unknown> = Record<string, unknown>> = {
     /**
      * The option ID to render as selected in the select box.
      *
@@ -78,9 +78,10 @@ export type SingleSelectProps<T = Record<string, any>> = {
     /** The initial value for uncontrolled mode. If `value` is provided, this is ignored. */
     defaultValue?: Option<T>['id'] | null;
     /**
-     * The interaction handler for the Select.
+     * The interaction handler for the Select. Receives the full selected {@link Option} (including
+     * its typed `metadata`), or `null` when the selection is cleared.
      */
-    onChange?: (value: Option<T>['id'] | null) => void | Promise<void>;
+    onChange?: (option: Option<T> | null) => void | Promise<void>;
     /**
      * The visual variant of the Select. `listbox` will render as a dropdown menu, `radio` will render as a radio group, `card` will render as selectable cards, and `segmented` will render as a segmented control.
      * @default listbox
@@ -88,9 +89,9 @@ export type SingleSelectProps<T = Record<string, any>> = {
     kind?: 'listbox' | 'radio' | 'card' | 'segmented';
     multiple?: false;
     multipleItemsName?: never;
-} & CommonSelectProps;
+} & CommonSelectProps<T>;
 
-export type MultiSelectProps<T = Record<string, any>> = {
+export type MultiSelectProps<T extends Record<string, unknown> = Record<string, unknown>> = {
     /**
      * Controls the text of the Multiselect button when multiple items selected, such as "All ___" or "2 ___"
      * @default items
@@ -112,15 +113,304 @@ export type MultiSelectProps<T = Record<string, any>> = {
     /** The initial value for uncontrolled multi-select. If `value` is provided, this is ignored. */
     defaultValue?: Option<T>['id'][] | null;
     /**
-     * The interaction handler for the Select.
+     * The interaction handler for the Select. Receives the full selected {@link Option}s (including
+     * their typed `metadata`), or `null` when nothing is selected.
      */
-    onChange?: (value: Option<T>['id'][] | null) => void | Promise<void>;
-} & CommonSelectProps;
+    onChange?: (options: Option<T>[] | null) => void | Promise<void>;
+} & CommonSelectProps<T>;
 
-type SelectProps<T = Record<string, any>> = SingleSelectProps<T> | MultiSelectProps<T>;
+type SelectProps<T extends Record<string, unknown> = Record<string, unknown>> =
+    | SingleSelectProps<T>
+    | MultiSelectProps<T>;
+
+const SelectRender = <T extends Record<string, unknown> = Record<string, unknown>>(
+    {
+        options,
+        value,
+        defaultValue,
+        onChange,
+        label,
+        status,
+        hideLabel,
+        description,
+        hideDescription,
+        descriptionPosition,
+        placeholder,
+        startEnhancer,
+        endEnhancer,
+        disabled,
+        kind = 'listbox',
+        maxHeight = 320,
+        hasOptionBorder = false,
+        multiple = false,
+        multipleItemsName,
+        segmentedHeight = 'compact',
+        onOpenChange,
+        overrides,
+    }: SelectProps<T>,
+    ref: ForwardedRef<HTMLElement>,
+) => {
+    const inputID = useId();
+    const multiItems = multipleItemsName || 'items';
+
+    // The single forwarded ref lands on the listbox trigger (button) or the radio/card/segmented
+    // group (div) depending on `kind`; narrow it per element type at each usage.
+    const listboxButtonRef = ref as ForwardedRef<HTMLButtonElement>;
+    const radioGroupRef = ref as ForwardedRef<HTMLDivElement>;
+
+    // Internally the selection is tracked by option id(s) (what Headless UI's Listbox/RadioGroup
+    // use). Translate back to the full typed Option(s) before invoking the public onChange.
+    const [resolvedValue, setResolvedValue] = useControllableState<string | string[] | null>({
+        value: value as string | string[] | null | undefined,
+        defaultValue: defaultValue ?? (multiple ? ([] as string[]) : null),
+        onChange: (next) => {
+            if (multiple) {
+                const ids = (next as string[] | null) ?? [];
+                const selected = ids
+                    .map((id) => options.find((o) => o.id === id))
+                    .filter((o): o is Option<T> => Boolean(o));
+                (onChange as MultiSelectProps<T>['onChange'])?.(selected.length ? selected : null);
+            } else {
+                const id = next as string | null;
+                const selected = id != null ? (options.find((o) => o.id === id) ?? null) : null;
+                (onChange as SingleSelectProps<T>['onChange'])?.(selected);
+            }
+        },
+    });
+
+    // TypeScript can't track discriminated union correlation through destructuring and JSX conditionals.
+    // For Listbox: supports both single and multi via overloads, needs explicit union types
+    // For RadioGroup: only supports single-select, needs narrowed types
+    const listboxValue = resolvedValue as string | string[] | null | undefined;
+    const listboxOnChange = setResolvedValue as (value: string | string[] | null) => void;
+    const singleValue = resolvedValue as string | null | undefined;
+    const singleOnChange = setResolvedValue as (value: string | null) => void;
+    const buttonText = () => {
+        if (!resolvedValue || (resolvedValue as string | string[]).length === 0) {
+            return placeholder || 'Select an option';
+        }
+        if (!multiple) {
+            return options?.find((o) => o.id === resolvedValue)?.node;
+        }
+        if (resolvedValue && (resolvedValue as string[]).length === 1) {
+            return options?.find((o) => o.id === (resolvedValue as string[])[0])?.node;
+        }
+        if ((resolvedValue as string[]).length === options.length) {
+            return `All ${multiItems}`;
+        }
+        return `${(resolvedValue as string[]).length} ${multiItems}`;
+    };
+    return (
+        <Field
+            htmlFor={inputID}
+            label={label}
+            hideLabel={hideLabel}
+            description={description}
+            hideDescription={hideDescription}
+            descriptionPosition={descriptionPosition}
+            disabled={disabled}
+            overrides={{
+                container: overrides?.container,
+                label: overrides?.label,
+                description: overrides?.description,
+            }}
+        >
+            {kind === 'listbox' && (
+                <Listbox as="div" value={listboxValue} onChange={listboxOnChange} multiple={multiple}>
+                    {({ open }) => (
+                        <>
+                            <OpenChangeEffect open={open} onOpenChange={onOpenChange} />
+                            <ListboxButton
+                                ref={listboxButtonRef}
+                                id={inputID}
+                                {...overrides?.selectInput}
+                                aria-disabled={disabled}
+                                data-status={disabled ? 'disabled' : status || 'default'}
+                                className={clsx(
+                                    overrides?.selectInput?.className,
+                                    inputStyles.inputContainer,
+                                    styles.listboxButton,
+                                    styles.field,
+                                )}
+                            >
+                                {!!startEnhancer && (
+                                    <div
+                                        {...overrides?.startEnhancerContainer}
+                                        className={clsx(
+                                            inputStyles.enhancer,
+                                            overrides?.startEnhancerContainer?.className,
+                                        )}
+                                        data-status={disabled ? 'disabled' : status || 'default'}
+                                    >
+                                        {!!startEnhancer && (
+                                            <MemoizedEnhancer
+                                                enhancer={startEnhancer}
+                                                size={parseInt(
+                                                    pget('typography.styles.paragraphSmall.fontSize') ||
+                                                        theme.typography.styles.paragraphSmall.fontSize,
+                                                    10,
+                                                )}
+                                            />
+                                        )}
+                                    </div>
+                                )}
+                                {buttonText()}
+                                {endEnhancer ? (
+                                    <div
+                                        {...overrides?.endEnhancerContainer}
+                                        className={clsx(
+                                            inputStyles.enhancer,
+                                            overrides?.endEnhancerContainer?.className,
+                                        )}
+                                        data-status={disabled ? 'disabled' : status || 'default'}
+                                    >
+                                        {!!endEnhancer && (
+                                            <MemoizedEnhancer
+                                                enhancer={endEnhancer}
+                                                size={parseInt(
+                                                    pget('typography.styles.paragraphSmall.fontSize') ||
+                                                        theme.typography.styles.paragraphSmall.fontSize,
+                                                    10,
+                                                )}
+                                            />
+                                        )}
+                                    </div>
+                                ) : (
+                                    <FontAwesomeIcon
+                                        className={clsx(inputStyles.enhancer, styles.chevron)}
+                                        data-status={disabled ? 'disabled' : status || 'default'}
+                                        width="10px"
+                                        icon={faChevronDown}
+                                    />
+                                )}
+                            </ListboxButton>
+                            <ListboxOptions
+                                anchor="bottom start"
+                                transition
+                                className={clsx(overrides?.optionsContainer, styles.options)}
+                                style={
+                                    {
+                                        '--options-maxHeight': `${maxHeight}px`,
+                                    } as CSSProperties
+                                }
+                            >
+                                {(options || []).map((option) => (
+                                    <ListboxOption
+                                        key={option.id}
+                                        value={option.id}
+                                        className={clsx(
+                                            overrides?.option,
+                                            styles.option,
+                                            hasOptionBorder && styles.optionBorder,
+                                        )}
+                                        disabled={option.disabled || false}
+                                    >
+                                        {typeof option.node === 'string' ? (
+                                            <Text as="span" kind="paragraphSmall">
+                                                {option.node}
+                                            </Text>
+                                        ) : (
+                                            option.node
+                                        )}
+                                        <Icon icon={Check} size={12} className={styles.check} />
+                                    </ListboxOption>
+                                ))}
+                            </ListboxOptions>
+                        </>
+                    )}
+                </Listbox>
+            )}
+            {kind === 'radio' && (
+                <RadioGroup
+                    ref={radioGroupRef}
+                    as="div"
+                    className={styles.radioContainer}
+                    value={singleValue}
+                    onChange={singleOnChange}
+                >
+                    {options.map((option) => (
+                        <Radio
+                            as="div"
+                            className={clsx(styles.radioOption)}
+                            key={option.id}
+                            value={option.id}
+                            disabled={option.disabled || false}
+                            data-status={disabled ? 'disabled' : status || 'default'}
+                        >
+                            <div className={styles.radioCircle} />
+                            <TextWhenString kind="paragraphXSmall">{option.node}</TextWhenString>
+                        </Radio>
+                    ))}
+                </RadioGroup>
+            )}
+            {kind === 'card' && (
+                <RadioGroup
+                    ref={radioGroupRef}
+                    as="div"
+                    className={styles.cardContainer}
+                    value={singleValue}
+                    onChange={singleOnChange}
+                >
+                    {options.map((option) => (
+                        <Radio
+                            as="div"
+                            className={clsx(styles.cardOption)}
+                            key={option.id}
+                            value={option.id}
+                            disabled={option.disabled || false}
+                            data-status={disabled ? 'disabled' : status || 'default'}
+                        >
+                            <div className={clsx(styles.cardSurface, typeof option.node === 'string' && styles.text)}>
+                                <TextWhenString kind="paragraphSmall">{option.node}</TextWhenString>
+                            </div>
+                        </Radio>
+                    ))}
+                </RadioGroup>
+            )}
+            {kind === 'segmented' && (
+                <RadioGroup
+                    ref={radioGroupRef}
+                    as="div"
+                    className={styles.segmentedContainer}
+                    value={singleValue ?? options[0].id}
+                    onChange={singleOnChange}
+                >
+                    {options.map((option) => (
+                        <Radio
+                            as="div"
+                            className={clsx(styles.segmentedOption, styles[segmentedHeight])}
+                            key={option.id}
+                            value={option.id}
+                            disabled={option.disabled || false}
+                            data-status={disabled ? 'disabled' : status || 'default'}
+                        >
+                            {(option.id === resolvedValue || (!resolvedValue && option.id === options[0].id)) && (
+                                <motion.div
+                                    className={styles.segmentedBackground}
+                                    layoutId={`${inputID}-segmented-selected`}
+                                    transition={{
+                                        ease: [0.42, 0.0, 0.58, 1.0],
+                                        duration: 0.25,
+                                    }}
+                                />
+                            )}
+                            <TextWhenString kind="paragraphXSmall" weight="medium" className={styles.segmentedText}>
+                                {option.node}
+                            </TextWhenString>
+                        </Radio>
+                    ))}
+                </RadioGroup>
+            )}
+        </Field>
+    );
+};
 
 /**
  * A Select component is used to render a `select` box.
+ *
+ * The component is generic over the option `metadata` type: pass a type parameter
+ * (`<Select<MyMeta> />`) and `options` / `onChange` become typed accordingly. `onChange` receives
+ * the full selected {@link Option} (single) or `Option[]` (multiple), including typed `metadata`.
  *
  * <hr />
  *
@@ -129,271 +419,9 @@ type SelectProps<T = Record<string, any>> = SingleSelectProps<T> | MultiSelectPr
  * ```js
  * import { Select } from 'paris/select';
  * ```
- * @constructor
  */
-export const Select = forwardRef(
-    <T = Record<string, any>>(
-        {
-            options,
-            value,
-            defaultValue,
-            onChange,
-            label,
-            status,
-            hideLabel,
-            description,
-            hideDescription,
-            descriptionPosition,
-            placeholder,
-            startEnhancer,
-            endEnhancer,
-            disabled,
-            kind = 'listbox',
-            maxHeight = 320,
-            hasOptionBorder = false,
-            multiple = false,
-            multipleItemsName,
-            segmentedHeight = 'compact',
-            onOpenChange,
-            overrides,
-        }: SelectProps<T>,
-        ref: ForwardedRef<any>,
-    ) => {
-        const inputID = useId();
-        const multiItems = multipleItemsName || 'items';
-
-        const [resolvedValue, setResolvedValue] = useControllableState<string | string[] | null>({
-            value: value as string | string[] | null | undefined,
-            defaultValue: defaultValue ?? (multiple ? ([] as string[]) : null),
-            onChange: onChange as ((value: string | string[] | null) => void) | undefined,
-        });
-
-        // TypeScript can't track discriminated union correlation through destructuring and JSX conditionals.
-        // For Listbox: supports both single and multi via overloads, needs explicit union types
-        // For RadioGroup: only supports single-select, needs narrowed types
-        const listboxValue = resolvedValue as string | string[] | null | undefined;
-        const listboxOnChange = setResolvedValue as (value: string | string[] | null) => void;
-        const singleValue = resolvedValue as string | null | undefined;
-        const singleOnChange = setResolvedValue as (value: string | null) => void;
-        const buttonText = () => {
-            if (!resolvedValue || (resolvedValue as string | string[]).length === 0) {
-                return placeholder || 'Select an option';
-            }
-            if (!multiple) {
-                return options?.find((o) => o.id === resolvedValue)?.node;
-            }
-            if (resolvedValue && (resolvedValue as string[]).length === 1) {
-                return options?.find((o) => o.id === (resolvedValue as string[])[0])?.node;
-            }
-            if ((resolvedValue as string[]).length === options.length) {
-                return `All ${multiItems}`;
-            }
-            return `${(resolvedValue as string[]).length} ${multiItems}`;
-        };
-        return (
-            <Field
-                htmlFor={inputID}
-                label={label}
-                hideLabel={hideLabel}
-                description={description}
-                hideDescription={hideDescription}
-                descriptionPosition={descriptionPosition}
-                disabled={disabled}
-                overrides={{
-                    container: overrides?.container,
-                    label: overrides?.label,
-                    description: overrides?.description,
-                }}
-            >
-                {kind === 'listbox' && (
-                    <Listbox as="div" value={listboxValue} onChange={listboxOnChange} multiple={multiple}>
-                        {({ open }) => (
-                            <>
-                                <OpenChangeEffect open={open} onOpenChange={onOpenChange} />
-                                <ListboxButton
-                                    ref={ref}
-                                    id={inputID}
-                                    {...overrides?.selectInput}
-                                    aria-disabled={disabled}
-                                    data-status={disabled ? 'disabled' : status || 'default'}
-                                    className={clsx(
-                                        overrides?.selectInput?.className,
-                                        inputStyles.inputContainer,
-                                        styles.listboxButton,
-                                        styles.field,
-                                    )}
-                                >
-                                    {!!startEnhancer && (
-                                        <div
-                                            {...overrides?.startEnhancerContainer}
-                                            className={clsx(
-                                                inputStyles.enhancer,
-                                                overrides?.startEnhancerContainer?.className,
-                                            )}
-                                            data-status={disabled ? 'disabled' : status || 'default'}
-                                        >
-                                            {!!startEnhancer && (
-                                                <MemoizedEnhancer
-                                                    enhancer={startEnhancer}
-                                                    size={parseInt(
-                                                        pget('typography.styles.paragraphSmall.fontSize') ||
-                                                            theme.typography.styles.paragraphSmall.fontSize,
-                                                        10,
-                                                    )}
-                                                />
-                                            )}
-                                        </div>
-                                    )}
-                                    {buttonText()}
-                                    {endEnhancer ? (
-                                        <div
-                                            {...overrides?.endEnhancerContainer}
-                                            className={clsx(
-                                                inputStyles.enhancer,
-                                                overrides?.endEnhancerContainer?.className,
-                                            )}
-                                            data-status={disabled ? 'disabled' : status || 'default'}
-                                        >
-                                            {!!endEnhancer && (
-                                                <MemoizedEnhancer
-                                                    enhancer={endEnhancer}
-                                                    size={parseInt(
-                                                        pget('typography.styles.paragraphSmall.fontSize') ||
-                                                            theme.typography.styles.paragraphSmall.fontSize,
-                                                        10,
-                                                    )}
-                                                />
-                                            )}
-                                        </div>
-                                    ) : (
-                                        <FontAwesomeIcon
-                                            className={clsx(inputStyles.enhancer, styles.chevron)}
-                                            data-status={disabled ? 'disabled' : status || 'default'}
-                                            width="10px"
-                                            icon={faChevronDown}
-                                        />
-                                    )}
-                                </ListboxButton>
-                                <ListboxOptions
-                                    anchor="bottom start"
-                                    transition
-                                    className={clsx(overrides?.optionsContainer, styles.options)}
-                                    style={
-                                        {
-                                            '--options-maxHeight': `${maxHeight}px`,
-                                        } as CSSProperties
-                                    }
-                                >
-                                    {(options || []).map((option) => (
-                                        <ListboxOption
-                                            key={option.id}
-                                            value={option.id}
-                                            className={clsx(
-                                                overrides?.option,
-                                                styles.option,
-                                                hasOptionBorder && styles.optionBorder,
-                                            )}
-                                            disabled={option.disabled || false}
-                                        >
-                                            {typeof option.node === 'string' ? (
-                                                <Text as="span" kind="paragraphSmall">
-                                                    {option.node}
-                                                </Text>
-                                            ) : (
-                                                option.node
-                                            )}
-                                            <Icon icon={Check} size={12} className={styles.check} />
-                                        </ListboxOption>
-                                    ))}
-                                </ListboxOptions>
-                            </>
-                        )}
-                    </Listbox>
-                )}
-                {kind === 'radio' && (
-                    <RadioGroup
-                        ref={ref}
-                        as="div"
-                        className={styles.radioContainer}
-                        value={singleValue}
-                        onChange={singleOnChange}
-                    >
-                        {options.map((option) => (
-                            <Radio
-                                as="div"
-                                className={clsx(styles.radioOption)}
-                                key={option.id}
-                                value={option.id}
-                                disabled={option.disabled || false}
-                                data-status={disabled ? 'disabled' : status || 'default'}
-                            >
-                                <div className={styles.radioCircle} />
-                                <TextWhenString kind="paragraphXSmall">{option.node}</TextWhenString>
-                            </Radio>
-                        ))}
-                    </RadioGroup>
-                )}
-                {kind === 'card' && (
-                    <RadioGroup
-                        ref={ref}
-                        as="div"
-                        className={styles.cardContainer}
-                        value={singleValue}
-                        onChange={singleOnChange}
-                    >
-                        {options.map((option) => (
-                            <Radio
-                                as="div"
-                                className={clsx(styles.cardOption)}
-                                key={option.id}
-                                value={option.id}
-                                disabled={option.disabled || false}
-                                data-status={disabled ? 'disabled' : status || 'default'}
-                            >
-                                <div
-                                    className={clsx(styles.cardSurface, typeof option.node === 'string' && styles.text)}
-                                >
-                                    <TextWhenString kind="paragraphSmall">{option.node}</TextWhenString>
-                                </div>
-                            </Radio>
-                        ))}
-                    </RadioGroup>
-                )}
-                {kind === 'segmented' && (
-                    <RadioGroup
-                        ref={ref}
-                        as="div"
-                        className={styles.segmentedContainer}
-                        value={singleValue ?? options[0].id}
-                        onChange={singleOnChange}
-                    >
-                        {options.map((option) => (
-                            <Radio
-                                as="div"
-                                className={clsx(styles.segmentedOption, styles[segmentedHeight])}
-                                key={option.id}
-                                value={option.id}
-                                disabled={option.disabled || false}
-                                data-status={disabled ? 'disabled' : status || 'default'}
-                            >
-                                {(option.id === resolvedValue || (!resolvedValue && option.id === options[0].id)) && (
-                                    <motion.div
-                                        className={styles.segmentedBackground}
-                                        layoutId={`${inputID}-segmented-selected`}
-                                        transition={{
-                                            ease: [0.42, 0.0, 0.58, 1.0],
-                                            duration: 0.25,
-                                        }}
-                                    />
-                                )}
-                                <TextWhenString kind="paragraphXSmall" weight="medium" className={styles.segmentedText}>
-                                    {option.node}
-                                </TextWhenString>
-                            </Radio>
-                        ))}
-                    </RadioGroup>
-                )}
-            </Field>
-        );
-    },
-);
+export const Select = forwardRef(SelectRender) as unknown as <
+    T extends Record<string, unknown> = Record<string, unknown>,
+>(
+    props: SelectProps<T> & RefAttributes<HTMLElement>,
+) => ReactNode;

--- a/src/stories/select/Select.tsx
+++ b/src/stories/select/Select.tsx
@@ -206,11 +206,12 @@ export const Select = forwardRef(
                 }}
             >
                 {kind === 'listbox' && (
-                    <Listbox as="div" ref={ref} value={listboxValue} onChange={listboxOnChange} multiple={multiple}>
+                    <Listbox as="div" value={listboxValue} onChange={listboxOnChange} multiple={multiple}>
                         {({ open }) => (
                             <>
                                 <OpenChangeEffect open={open} onOpenChange={onOpenChange} />
                                 <ListboxButton
+                                    ref={ref}
                                     id={inputID}
                                     {...overrides?.selectInput}
                                     aria-disabled={disabled}

--- a/src/stories/select/Select.tsx
+++ b/src/stories/select/Select.tsx
@@ -324,6 +324,7 @@ const SelectRender = <T extends Record<string, unknown> = Record<string, unknown
                 <RadioGroup
                     ref={radioGroupRef}
                     as="div"
+                    tabIndex={-1}
                     className={styles.radioContainer}
                     value={singleValue}
                     onChange={singleOnChange}
@@ -347,6 +348,7 @@ const SelectRender = <T extends Record<string, unknown> = Record<string, unknown
                 <RadioGroup
                     ref={radioGroupRef}
                     as="div"
+                    tabIndex={-1}
                     className={styles.cardContainer}
                     value={singleValue}
                     onChange={singleOnChange}
@@ -371,6 +373,7 @@ const SelectRender = <T extends Record<string, unknown> = Record<string, unknown
                 <RadioGroup
                     ref={radioGroupRef}
                     as="div"
+                    tabIndex={-1}
                     className={styles.segmentedContainer}
                     value={singleValue ?? options[0].id}
                     onChange={singleOnChange}

--- a/src/stories/tabs/Tabs.test.tsx
+++ b/src/stories/tabs/Tabs.test.tsx
@@ -70,7 +70,23 @@ describe('Tabs', () => {
         await user.click(tabs[2]);
 
         await waitFor(() => {
-            expect(onTabChange).toHaveBeenCalledWith(2);
+            expect(onTabChange).toHaveBeenCalledWith(2, undefined);
+        });
+    });
+
+    it('passes the selected tab id to onTabChange when tabs have ids', async () => {
+        const onTabChange = vi.fn();
+        const tabsWithIds = [
+            { title: 'Transactions', content: 'Transactions content', id: 'transactions' },
+            { title: 'Cards', content: 'Cards content', id: 'cards' },
+            { title: 'Documents', content: 'Documents content', id: 'documents' },
+        ] as const;
+        const { user } = render(<Tabs tabs={[...tabsWithIds]} onTabChange={onTabChange} />);
+
+        await user.click(screen.getAllByRole('tab')[2]);
+
+        await waitFor(() => {
+            expect(onTabChange).toHaveBeenCalledWith(2, 'documents');
         });
     });
 

--- a/src/stories/tabs/Tabs.tsx
+++ b/src/stories/tabs/Tabs.tsx
@@ -6,13 +6,13 @@ import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
 import type { CSSLength } from '@ssh/csstypes';
 import { clsx } from 'clsx';
 import { motion } from 'framer-motion';
-import type { ComponentPropsWithoutRef, CSSProperties, FC, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from 'react';
 import { useId, useState } from 'react';
 import typography from '../text/Typography.module.css';
 import { easeInOutExpo } from '../utility';
 import styles from './Tabs.module.scss';
 
-export type TabsProps = {
+export type TabsProps<TID extends string = string> = {
     /**
      * The tabs to render.
      */
@@ -21,6 +21,11 @@ export type TabsProps = {
         title: string;
         /** The content of the tab. */
         content: ReactNode;
+        /**
+         * An optional stable identifier for the tab. When provided, it is passed to `onTabChange`
+         * as the second argument, letting consumers switch on a typed id instead of a bare index.
+         */
+        id?: TID;
     }[];
     /**
      * The width of each tab. Defaults to `150px`.
@@ -54,8 +59,9 @@ export type TabsProps = {
     /**
      * An optional handler for tab changes.
      * @param index - The index of the tab that was selected.
+     * @param id - The `id` of the selected tab, if one was provided in the `tabs` array.
      */
-    onTabChange?: (index: number) => void | Promise<void>;
+    onTabChange?: (index: number, id: TID | undefined) => void | Promise<void>;
     /**
      * Prop overrides for other rendered elements. Overrides for the input itself should be passed directly to the component.
      */
@@ -82,7 +88,7 @@ export type TabsProps = {
  * ```
  * @constructor
  */
-export const Tabs: FC<TabsProps> = ({
+export const Tabs = <TID extends string = string>({
     tabs,
     tabWidth = '150px',
     kind = 'auto',
@@ -92,7 +98,7 @@ export const Tabs: FC<TabsProps> = ({
     index,
     onTabChange,
     overrides,
-}) => {
+}: TabsProps<TID>): ReactNode => {
     const id = useId();
     const [selectedIndex, setSelectedIndex] = useState(defaultIndex);
 
@@ -102,9 +108,7 @@ export const Tabs: FC<TabsProps> = ({
             selectedIndex={index ?? selectedIndex}
             onChange={(i) => {
                 setSelectedIndex(i);
-                if (onTabChange) {
-                    onTabChange?.(i);
-                }
+                onTabChange?.(i, tabs[i]?.id);
             }}
             {...overrides?.group}
             className={clsx(styles.tabGroup, styles[backgroundStyle], overrides?.group?.className)}

--- a/src/stories/utility/TextWhenString.tsx
+++ b/src/stories/utility/TextWhenString.tsx
@@ -1,15 +1,14 @@
-import type { PropsWithChildren } from 'react';
-import { memo } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import type { TextElement, TextProps } from '../text';
 import { Text } from '../text';
 
 /**
- * A memoized component that renders its children as a {@link Text} component if `children` is just a string.
+ * Renders its children as a {@link Text} component if `children` is just a string.
  */
-export const TextWhenString = memo<PropsWithChildren<TextProps<TextElement>>>(({ children, ...props }) => {
+export const TextWhenString: FC<PropsWithChildren<TextProps<TextElement>>> = ({ children, ...props }) => {
     if (typeof children === 'string' || typeof children === 'number') {
         return <Text {...props}>{children}</Text>;
     }
 
     return <>{children}</>;
-});
+};


### PR DESCRIPTION
This PR (incremental — more commits may land before merge):

### Form focus & error state
Programmatic focus (`setFocus`) and per-field error state across form components:

- Form inputs forward a `ref` to their focusable element (`Input`, `Select`, `Combobox`, `Checkbox`, `CodeInput`, `AccordionSelect`) so form libraries (e.g. react-hook-form's `setFocus`) can focus a field when it's invalid.
- `Select`'s `radio`/`card`/`segmented` kinds are now focusable (the group carries `tabIndex={-1}`).
- `Combobox` keeps a focusable ref target even when the selected option's `node` is a non-string element.
- `MarkdownEditor` exposes an imperative `ref` handle (`MarkdownEditorHandle` with `focus()`).
- `Checkbox` and `AccordionSelect` gain `status?: 'default' | 'error'`, matching `Input`/`Select`.
- `Drawer` adds `onPageEntered(pageID)`, fired once a paginated page has mounted after its enter transition, so consumers can focus a field on a newly-navigated page deterministically.

### Generic option components
- `Select`, `AccordionSelect`, and `Combobox` are genuinely generic over their option `metadata` type (`<Select<MyMeta> />`), preserved across `forwardRef`.
- `Tabs` is generic over an optional per-tab `id`, surfaced as the second arg of `onTabChange(index, id)`.
- `Option`/`AccordionSelectOption` metadata defaults to `Record<string, unknown>`.

### ⚠️ Breaking change
`Select`'s `onChange` now receives the full selected `Option<T>` (single) / `Option<T>[]` (multiple), including typed `metadata`, **instead of the option `id` string(s)**. `value`/`defaultValue` are unchanged (still id-based). Migrate by reading `option.id`:

```tsx
// before
<Select options={opts} onChange={(id) => setValue(id)} />
// after
<Select options={opts} onChange={(option) => setValue(option?.id ?? null)} />
```

Shipped as a `minor` bump (0.x) — see `.changeset/`.

### Component fixes & props
- **Button** — notification dot sits in the top-right corner and applies the button's hover fill while shown; `corners` is controllable in Storybook.
- **Menu** — `verticalPosition` prop to open above the button (default stays below); no longer paints a stray shadow when it has no items.
- **Select** — hides the dropdown popup when it has no options, so an engaged field stops casting a stray shadow.
- **CardButton** — corrects the `raised` hover border ring and adds an `overrides` prop (`container`, `card`).
- **Field** — ignores clicks bubbling from portaled descendants, so a tapped option can't reopen the dropdown.
- **TextWhenString** — dropped the unnecessary `memo` wrapper.

### Docs
`llms.txt`, `AGENTS.md`, and `CLAUDE.md` updated for the generic option components, the breaking `Select` `onChange`, and the focus/error-state APIs.

## Checklist
- [ ] Verify `setFocus` reaches each form input when its field is invalid: `Select` radio/card/segmented kinds, `Combobox` with a non-string selected node, and `MarkdownEditor` (via its `ref` handle).
- [ ] Migrate `Select` consumers to the new `onChange(option)` signature — breaking; read `option.id`.
- [ ] Confirm `Checkbox`/`AccordionSelect` `status="error"` renders the intended invalid treatment (design sign-off).
- [ ] Verify `Drawer` `onPageEntered` fires after the target page mounts across all three `pageTransition` modes (none/crossfade/slide).
- [ ] Confirm the Button notification dot sits top-right with the hover fill across `primary`/`secondary`/`tertiary` (design sign-off).
- [ ] Confirm an engaged Combobox/Select with zero options no longer casts a stray shadow, and normal dropdowns are unaffected.
- [ ] Confirm `Menu` `verticalPosition="top"` opens above the button; default (bottom) unchanged.
- [ ] Sanity-check `<Select<MyMeta> />` / `<AccordionSelect<MyMeta> />` generic ergonomics in a real consumer.